### PR TITLE
Fixed: CURLOPT_DNS_SERVERS + Curl.duphandle in curl-helper.c

### DIFF
--- a/curl-helper.c
+++ b/curl-helper.c
@@ -114,6 +114,8 @@ enum OcamlValues
     OcamlSSHHostPublicKeyMD5,
     OcamlCopyPostFields,
 
+    OcamlDNSServers,
+
     /* Not used, last for size */
     OcamlValuesSize
 };
@@ -1412,6 +1414,10 @@ static Connection *duplicateConnection(Connection *original)
         handleCopyPostFields(connection,
                              Field(original->ocamlValues,
                                    OcamlCopyPostFields));
+    if (Field(original->ocamlValues, OcamlDNSServers) != Val_unit)
+        handleDnsServers(connection,
+                         Field(original->ocamlValues,
+                               OcamlDNSServers));
 
     return connection;
 }
@@ -5494,6 +5500,8 @@ static void handleResolve(Connection *conn, value option)
 static void handleDnsServers(Connection *conn, value option)
 {
   CAMLparam1(option);
+
+  Store_field(conn->ocamlValues, OcamlDNSServers, option);
 
   CURLcode result = CURLE_OK;
   free_if(conn->dns_servers);


### PR DESCRIPTION
...r.c

Given a handle with `CURLOPT_DNS_SERVERS` set, a duplicate would still point to the same argument memory location, as the argument isn't set anew in `duplicateConnection(..)`. The original could be garbage collected and the space used otherwise, while the duplicate would still point to it, potentially leading to errors during `Curl.perform` on the duplicate.

I couldn't produce that exact error, although it could be shown that the argument is not copied. Therefore this error could be possible.

Greetings
