### PR TITLE
Various fixes for Windows building with mingw32

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+install-sh eol=lf
+configure eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.lib
 *.dll
 *.so
+*.exe
 config.*
 .depend
 Makefile

--- a/META
+++ b/META
@@ -1,7 +1,7 @@
 name="curl"
 version=""
 description="bindings to libcurl"
-requires=""
+requires="unix"
 archive(byte)="curl.cma"
 archive(native)="curl.cmxa"
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -25,9 +25,11 @@ CURLHELPEROBJS	= curl-helper.o
 CURLOBJS	= curl.cmx
 CURLBCOBJS	= $(CURLOBJS:.cmx=.cmo)
 
+SO=$(shell ocamlc -config | fgrep ext_dll | sed -e "s/.*: //")
+
 CLIBS = @CURLLIBS@
 
-TARGETS := curl.cma libcurl-helper.a dllcurl-helper.so
+TARGETS := curl.cma libcurl-helper.a dllcurl-helper$(SO)
 ifneq (@OCAML_PKG_lwt@,no)
 TARGETS += curl_lwt.cmo
 endif
@@ -60,10 +62,10 @@ targets:	$(TARGETS) examples
 examples:
 		(cd examples; $(MAKE))
 
-curl.cma:	$(CURLBCOBJS) dllcurl-helper.so
+curl.cma:	$(CURLBCOBJS) dllcurl-helper$(SO)
 		$(OCAMLMKLIB) -o curl $(CURLBCOBJS) -oc curl-helper $(CLIBS)
 
-curl.cmxa:	$(CURLOBJS) dllcurl-helper.so
+curl.cmxa:	$(CURLOBJS) dllcurl-helper$(SO)
 		$(OCAMLMKLIB) -o curl $(CURLOBJS) -oc curl-helper $(CLIBS)
 
 curl_lwt.cmo: curl_lwt.ml
@@ -84,7 +86,7 @@ curl_lwt.cmi: curl_lwt.mli
 .ml.cmo:
 		$(OCAMLC) -c $(FLAGS) $< -o $@
 
-libcurl-helper.a dllcurl-helper.so:	$(CURLHELPEROBJS)
+libcurl-helper.a dllcurl-helper$(SO):	$(CURLHELPEROBJS)
 		$(OCAMLMKLIB) -oc curl-helper $(CURLHELPEROBJS) $(CLIBS)
 
 .c.o:
@@ -119,7 +121,7 @@ release:
 	gpg -a -b $(NAME).tar.gz
 
 clean:
-		@rm -f $(TARGETS) *~ *.cm* *.o *.a *.so .depend core
+		@rm -f $(TARGETS) *~ *.cm* *.o *.a *$(SO) .depend core
 		@(cd examples; $(MAKE) clean)
 
 distclean: clean

--- a/curl-helper.c
+++ b/curl-helper.c
@@ -2495,7 +2495,20 @@ SETOPT_INT64( POSTFIELDSIZE_LARGE)
 #endif
 
 #if HAVE_DECL_CURLOPT_TCP_NODELAY
-SETOPT_BOOL( TCP_NODELAY)
+static void handle_TCP_NODELAY(Connection *conn, value option)
+{
+    CAMLparam1(option);
+    CURLcode result = CURLE_OK;
+
+    result = curl_easy_setopt(conn->connection,
+                              CURLOPT_TCP_NODELAY,
+                              Bool_val(option));
+
+    if (result != CURLE_OK)
+        raiseError(conn, result);
+
+    CAMLreturn0;
+}
 #endif
 
 #if HAVE_DECL_CURLOPT_FTPSSLAUTH

--- a/examples/test_memory_leaks.ml
+++ b/examples/test_memory_leaks.ml
@@ -11,9 +11,10 @@ let test1 () =
 
 let rss () =
   let path = Printf.sprintf "/proc/%d/statm" (Unix.getpid ()) in
-  match open_in path with
-  | exception exn -> Printf.eprintf "Error opening %s (%s), ignoring\n%!" path (Printexc.to_string exn); 0
-  | ch -> let n = Scanf.fscanf ch "%_d %d" (fun x -> 4*1024*x) in close_in_noerr ch; n
+  try
+    let ch = open_in path in
+    let n = Scanf.fscanf ch "%_d %d" (fun x -> 4*1024*x) in close_in_noerr ch; n
+  with exn -> Printf.eprintf "Error opening %s (%s), ignoring\n%!" path (Printexc.to_string exn); 0
 
 let () =
   let rss1 = rss () in


### PR DESCRIPTION
A few alterations in this branch for Windows building, originally against 0.7.2 but with some other changes:
* Hard-coded requirement for .so changed to read `ocamlc -config` (I've done this in a way which implies GNU make being used - it might be better if configure derived `$(SO)`?)
* Some minor git configuration changes when developing on Windows (`.gitignore`/`.gitattributes`)
* Two changes made since 0.7.2 were breaking build - not clear if it was Windows-only. I couldn't make out exactly why it wasn't working, but the fact that `TCP_NODELAY` is `0x0001` seemed to be getting in the way of `SETOPT_BOOL` - solution was to revert the change for this version, but it's not entirely satisfactory. Additionally, test_memory_leaks.ml was using 4.02's pattern matching on exceptions, which prevents building under 4.01. I opted to eliminate the syntax, rather than altering configure to exclude the test for OCaml < 4.02.0