### PR TITLE
Add Windows, Linux and OS X CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: c
+sudo: required
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
+script: bash -ex .travis-opam.sh
+env:
+  - OCAML_VERSION=4.00
+  - OCAML_VERSION=4.01
+  - OCAML_VERSION=4.02
+  - OCAML_VERSION=4.03
+  - OCAML_VERSION=4.04
+os:
+  - linux
+  - osx

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,13 @@
+platform:
+  - x86
+
+environment:
+  CYG_ROOT: "C:\\cygwin"
+  CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
+
+install:
+  - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh
+  - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P diffutils -P make -P unzip -P git -P m4 -P perl -P mingw64-x86_64-gcc-core"
+
+build_script:
+  - "%CYG_BASH% '${APPVEYOR_BUILD_FOLDER}/appveyor-opam.sh'"

--- a/opam
+++ b/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "ygrek@autistici.org"
+homepage: "http://ocurl.forge.ocamlcore.org"
+license: "MIT"
+authors: [ "Lars Nilsson" "ygrek" ]
+doc: ["http://ocurl.forge.ocamlcore.org/api/index.html"]
+dev-repo: "git://github.com/ygrek/ocurl.git"
+bug-reports: "https://github.com/ygrek/ocurl/issues"
+build: [
+  ["./configure"]
+  [make]
+]
+install: [
+  [make "install"]
+]
+build-test: [
+  [make "test"]
+]
+build-doc: [[make "doc"]]
+remove: [["ocamlfind" "remove" "curl"]]
+depends: [
+  "ocamlfind" {build}
+  "base-unix"
+  "conf-libcurl"
+]
+depopts: ["lwt"]


### PR DESCRIPTION
This PR adds a Travis file that tests ocurl on Linux and OS X and an AppVeyor config file that tests on Windows. To enable this in the main repository, you need to go turn on builds at both of these sites (as described at https://github.com/ocaml/ocaml-ci-scripts).

I have enabled them on my fork, and you can see the build results for this `ci` branch at:

  https://github.com/talex5/ocurl/branches

(click on the red x beside the `ci` branch)

Note that the Linux tests are currently failing due to #9, and the OS X tests are failing due to https://github.com/ocaml/opam-repository/issues/7456. Hopefully this PR will make these issues easier to fix.

Direct link to build results:

https://travis-ci.org/talex5/ocurl/builds/161260178
https://ci.appveyor.com/project/talex5-ci/ocurl/build/build-2

Thanks,