### PR TITLE
msvc CI

### DIFF
--- a/Makefile.msvc
+++ b/Makefile.msvc
@@ -21,6 +21,7 @@ FLAGS=
 
 CFLAGS=
 CURLINCDIR=$(CURLDIR)/include
+CURLLIBDIR=$(CURLDIR)/lib
 
 # PR#4783
 OCAMLMKLIB=ocamlmklib -v -ocamlc ocamlc -ocamlopt ocamlopt
@@ -30,13 +31,14 @@ CURLOBJS=curl.cmx
 CURLBCOBJS=$(CURLOBJS:.cmx=.cmo)
 
 CURLFLAGS=
-CURLCLIBS=ws2_32.lib
+CURLCLIBS=$(CURLLIBDIR)/libcurl.lib ws2_32.lib
 
 TARGETS=curl.cma curl.cmxa
 
 all:
 		@$(MAKE) -f Makefile.msvc depend
 		@$(MAKE) -f Makefile.msvc targets
+		@$(MAKE) -f Makefile.msvc examples
 
 targets:	$(TARGETS)
 

--- a/Makefile.msvc
+++ b/Makefile.msvc
@@ -3,7 +3,7 @@
 ###
 
 # libcurl directory
-CURLDIR = C:/cygwin/home/me/curl-7.54.1
+CURLDIR=C:/cygwin/home/me/curl-7.54.1
 
 #####################
 
@@ -11,28 +11,28 @@ CURLDIR = C:/cygwin/home/me/curl-7.54.1
 
 .SUFFIXES:	.ml .mli .cmx .cmi .cmo .cmxa .cma .c .obj
 
-OCBYTE		= ocamlc
-OCOPT		= ocamlopt
+OCBYTE=ocamlc
+OCOPT=ocamlopt
 
-OC		= ocamlc
-CC		= cl
+OC=ocamlc
+CC=cl
 
-FLAGS		=
+FLAGS=
 
-CFLAGS		=
-CURLINCDIR	= -I $(CURLDIR)/include
+CFLAGS=
+CURLINCDIR=$(CURLDIR)/include
 
 # PR#4783
-OCAMLMKLIB = ocamlmklib -v -ocamlc ocamlc -ocamlopt ocamlopt
+OCAMLMKLIB=ocamlmklib -v -ocamlc ocamlc -ocamlopt ocamlopt
 
-CURLHELPEROBJS	= curl-helper.obj
-CURLOBJS	= curl.cmx
-CURLBCOBJS	= $(CURLOBJS:.cmx=.cmo)
+CURLHELPEROBJS=curl-helper.obj
+CURLOBJS=curl.cmx
+CURLBCOBJS=$(CURLOBJS:.cmx=.cmo)
 
-CURLFLAGS	=
-CURLCLIBS	= ws2_32.lib
+CURLFLAGS=
+CURLCLIBS=ws2_32.lib
 
-TARGETS		= curl.cma curl.cmxa
+TARGETS=curl.cma curl.cmxa
 
 all:
 		@$(MAKE) -f Makefile.msvc depend
@@ -62,7 +62,7 @@ libcurl-helper.lib dllcurl-helper.dll:	$(CURLHELPEROBJS)
 		$(OCAMLMKLIB) -oc curl-helper $(CURLHELPEROBJS) $(CURLCLIBS)
 
 .c.obj:
-		$(OC) -c $(CFLAGS) -ccopt -DHAVE_CONFIG_H $(CURLINCDIR) -ccopt /Tp $< -o $@
+		$(OC) -c $(CFLAGS) -ccopt -DHAVE_CONFIG_H -ccopt -I -ccopt $(CURLINCDIR) -ccopt /TP $< -o $@
 
 install:
 		ocamlfind install -ldconf ignore curl META $(wildcard *.cmi *.lib *.cma *.cmxa *.cmx *.dll *.mli)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,49 @@
 platform:
-  - x86
+  - x64
+
+image: Visual Studio 2015
 
 environment:
-  FORK_USER: ocaml
-  FORK_BRANCH: master
-  CYG_ROOT: C:\cygwin64
+  global:
+    CYG_ROOT: C:/cygwin
+    CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
+    CYG_CACHE: C:/cygwin/var/cache/setup
+    FLEXDLL_DIR: C:/flexdll
+    CURLVER: 7.54.1
+    CURLDIR: C:/curl-7.54.1
+  matrix:
+#    - OCAMLBRANCH: 4.02
+    - OCAMLBRANCH: 4.03
+    - OCAMLBRANCH: 4.04
+    - OCAMLBRANCH: 4.05
+    - OCAMLBRANCH: trunk
+  OCAMLROOT: C:/OCaml
+
+cache:
+  - C:/OCaml
 
 install:
-  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/$env:FORK_USER/ocaml-ci-scripts/$env:FORK_BRANCH/appveyor-install.ps1"))
+  - mkdir "%FLEXDLL_DIR%"
+  - appveyor DownloadFile "http://alain.frisch.fr/flexdll/flexdll-bin-0.35.zip" -FileName "flexdll.zip"
+  - appveyor DownloadFile "http://alain.frisch.fr/flexdll/flexdll-0.35.tar.gz" -FileName "flexdll.tar.gz"
+  - appveyor DownloadFile "https://curl.haxx.se/download/curl-7.54.1.zip" -FileName "curl-%CURLVER%.zip"
+  - mkdir flexdll-tmp
+  - cd flexdll-tmp
+  - 7z x -y ..\flexdll.zip
+  - for %%F in (flexdll.h flexlink.exe default_amd64.manifest) do copy %%F "%FLEXDLL_DIR%"
+  - cd ..
+  - 7z x -y -o"C:\" "curl-%CURLVER%.zip"
+  - dir "%CURLDIR%"
+  # Make sure the Cygwin path comes before the Git one (otherwise
+  # cygpath behaves crazily), but after the MSVC one.
+  - set Path=C:\cygwin\bin;%OCAMLROOT%\bin;C:\flexdll;%Path%
+  - '%CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin"'
+  - '"%CYG_ROOT%\setup-x86.exe" -qgnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P gcc-core -P cygwin64-gcc-core -P mingw64-i686-gcc-core -P mingw64-x86_64-gcc-core -P make >NUL'
+  - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat"
+  - appveyor DownloadFile "https://raw.githubusercontent.com/ocaml/ocaml/trunk/tools/msvs-promote-path" -FileName "msvs-promote-path"
 
 build_script:
-  - call %CYG_ROOT%\bin\bash.exe -l %APPVEYOR_BUILD_FOLDER%\appveyor-opam.sh
+  - "%CYG_ROOT%/bin/bash -lc \"echo 'eval $($APPVEYOR_BUILD_FOLDER/msvs-promote-path)' >> ~/.bash_profile\""
+  - '%CYG_ROOT%/bin/bash -lc "$APPVEYOR_BUILD_FOLDER/appveyor_build.sh"'
+
+test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ install:
   # cygpath behaves crazily), but after the MSVC one.
   - set Path=C:\cygwin\bin;%OCAMLROOT%\bin;C:\flexdll;%Path%
   - '%CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin"'
-  - '"%CYG_ROOT%\setup-x86.exe" -qgnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P gcc-core -P cygwin64-gcc-core -P mingw64-i686-gcc-core -P mingw64-x86_64-gcc-core -P make >NUL'
+  - '"%CYG_ROOT%\setup-x86.exe" -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P make >NUL'
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat"
   - appveyor DownloadFile "https://raw.githubusercontent.com/ocaml/ocaml/trunk/tools/msvs-promote-path" -FileName "msvs-promote-path"
 

--- a/appveyor_build.sh
+++ b/appveyor_build.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+function run {
+    NAME=$1
+    shift
+    echo "-=-=- $NAME -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-"
+    "$@"
+    CODE=$?
+    if [ $CODE -ne 0 ]; then
+        echo "-=-=- $NAME failed! -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-"
+        exit $CODE
+    else
+        echo "-=-=- End of $NAME -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-"
+    fi
+}
+
+echo ** OCAMLROOT=$OCAMLROOT
+
+cd $APPVEYOR_BUILD_FOLDER
+
+tar -xzf flexdll.tar.gz
+cd flexdll-0.35
+make MSVC_DETECT=0 CHAINS=msvc64 support
+cp flexdll*_msvc64.obj "$FLEXDLL_DIR"
+cd ..
+
+# Do not perform end-of-line conversion
+git config --global core.autocrlf false
+git clone https://github.com/ocaml/ocaml.git --branch $OCAMLBRANCH --depth 1 ocaml
+
+cd ocaml
+
+MAKEOCAML=make
+CONFIG_DIR=byterun/caml
+
+case $OCAMLBRANCH in
+    4.01|4.02|4.03|4.04|4.05)
+        MAKEOCAML="make -f Makefile.nt"
+        CONFIG_DIR=config
+        ;;
+esac
+
+if [ ! -f $OCAMLROOT/STAMP ] || [ "$(git rev-parse HEAD)" != "$(cat $OCAMLROOT/STAMP)" ]; then
+    cp config/m-nt.h $CONFIG_DIR/m.h
+    cp config/s-nt.h $CONFIG_DIR/s.h
+    #cp config/Makefile.msvc config/Makefile
+    cp config/Makefile.msvc64 config/Makefile
+
+    cp config/Makefile config/Makefile.bak
+    sed -e "s|PREFIX=.*|PREFIX=$OCAMLROOT|" \
+        -e "s|WITH_DEBUGGER=.*|WITH_DEBUGGER=|" \
+        -e "s|WITH_OCAMLDOC=.*|WITH_OCAMLDOC=|" \
+        config/Makefile.bak > config/Makefile
+    #run "Content of config/Makefile" cat config/Makefile
+
+    run "make world" $MAKEOCAML world
+    run "make opt" $MAKEOCAML opt
+    run "make install" $MAKEOCAML install
+
+    git rev-parse HEAD > $OCAMLROOT/STAMP
+fi
+
+export CAML_LD_LIBRARY_PATH=$OCAMLROOT/lib/stublibs
+
+cd $CURLDIR/winbuild
+
+run "make libcurl x64" nmake /f Makefile.vc MODE=dll MACHINE=x64
+
+cd $APPVEYOR_BUILD_FOLDER
+
+cp Makefile.msvc Makefile.msvc.bak
+
+sed -e "s|CURLDIR=.*|CURLDIR=$CURLDIR/builds/libcurl-vc-x64-release-dll-ipv6-sspi-winssl|" \
+    Makefile.msvc.bak > Makefile.msvc
+
+cp config.h.windows config.h
+
+run "Contents of ocurl/Makefile.msvc" cat Makefile.msvc
+
+run "make all" make -f Makefile.msvc targets

--- a/appveyor_build.sh
+++ b/appveyor_build.sh
@@ -77,4 +77,4 @@ cp config.h.windows config.h
 
 run "Contents of ocurl/Makefile.msvc" cat Makefile.msvc
 
-run "make all" make -f Makefile.msvc targets
+run "make all" make -f Makefile.msvc all

--- a/examples/Makefile.windows
+++ b/examples/Makefile.windows
@@ -16,7 +16,7 @@ LFLAGS=-I ..
 OCURLLIB=-dllpath .. unix.cma curl.cma
 OCURLOPTLIB=unix.cmxa curl.cmxa
 
-TARGETS=ocurl.exe ocurl.opt.exe oput.exe oput.opt.exe ominimal.exe ominimal.opt.exe ossl.exe ossl.opt.exe omulti.exe omulti.opt.exe test_cb_exn.exe
+TARGETS=ocurl.exe ocurl.opt.exe oput.exe oput.opt.exe ominimal.exe ominimal.opt.exe ossl.exe ossl.opt.exe test_cb_exn.exe # omulti.exe omulti.opt.exe
 
 all:
 		@$(MAKE) -f Makefile.windows depend

--- a/examples/Makefile.windows
+++ b/examples/Makefile.windows
@@ -4,19 +4,19 @@
 
 .SUFFIXES:	.ml .mli .cmx .cmi .cmo .cmxa .cma .c .obj
 
-OCBYTE		= ocamlc
-OCOPT		= ocamlopt
+OCBYTE=ocamlc
+OCOPT=ocamlopt
 
-OC		= ocamlc
-CC		= ocamlc
+OC=ocamlc
+CC=ocamlc
 
-FLAGS		= -I ..
-LFLAGS		= -I ..
+FLAGS=-I ..
+LFLAGS=-I ..
 
-OCURLLIB	= -dllpath .. curl.cma
-OCURLOPTLIB	= curl.cmxa
+OCURLLIB=-dllpath .. unix.cma curl.cma
+OCURLOPTLIB=unix.cmxa curl.cmxa
 
-TARGETS	= ocurl.exe ocurl.opt.exe oput.exe oput.opt.exe ominimal.exe ominimal.opt.exe ossl.exe ossl.opt.exe omulti.exe omulti.opt.exe test_cb_exn.exe
+TARGETS=ocurl.exe ocurl.opt.exe oput.exe oput.opt.exe ominimal.exe ominimal.opt.exe ossl.exe ossl.opt.exe omulti.exe omulti.opt.exe test_cb_exn.exe
 
 all:
 		@$(MAKE) -f Makefile.windows depend


### PR DESCRIPTION
As discussed, here is a first, rough, AppVeyor script to test the `msvc` build (no `opam`, tests 4.03, 4.04, 4.05, and trunk):

- It compiles OCaml using `msvc64` compiler (cached to avoid lengthy recompilation)
- It compiles `libcurl` dll using the same compiler
- It compiles `ocurl` using OCaml and `libcurl` above.
- It compiles the examples

This is a first cut - some refactoring is needed and also need to restore the functionality of the original mingw/opam test script.