### PR TITLE
Add support for CURLOPT_SSH_KNOWNHOSTS, CURLOPT_SSH_KEYFUNCTION

### DIFF
--- a/curl-helper.c
+++ b/curl-helper.c
@@ -1116,33 +1116,31 @@ static int cb_SSH_KEYFUNCTION(CURL *easy,
     caml_leave_blocking_section();
 
     CAMLparam0();
-    CAMLlocal4(known, found, mismatch, result);
+    CAMLlocal3(v_found, v_match, v_result);
     Connection *conn = (Connection *)clientp;
     int res = CURLKHSTAT_REJECT;
 
     switch (match) {
       case CURLKHMATCH_OK:
-        found = ml_copy_string(foundkey->key, foundkey->len ? foundkey->len : strlen(foundkey->key));
-        result = caml_callback2_exn(Field(conn->ocamlValues, Ocaml_SSH_KEYFUNCTION), Val_int(0), found);
+        v_match = Val_int(0);
         break;
       case CURLKHMATCH_MISMATCH:
-        found = ml_copy_string(foundkey->key, foundkey->len ? foundkey->len : strlen(foundkey->key));
-        known = ml_copy_string(knownkey->key, knownkey->len ? knownkey->len : strlen(knownkey->key));
-        mismatch = caml_alloc_small(1, 0);
-        Field(mismatch, 0) = found;
-        result = caml_callback2_exn(Field(conn->ocamlValues, Ocaml_SSH_KEYFUNCTION), mismatch, found);
+        v_match = caml_alloc_small(1, 0);
+        Field(v_match, 0) = ml_copy_string(knownkey->key, knownkey->len ? knownkey->len : strlen(knownkey->key));
         break;
       case CURLKHMATCH_MISSING:
-        found = ml_copy_string(foundkey->key, foundkey->len ? foundkey->len : strlen(foundkey->key));
-        result = caml_callback2_exn(Field(conn->ocamlValues, Ocaml_SSH_KEYFUNCTION), Val_int(1), found);
+        v_match = Val_int(1);
         break;
       default:
         caml_failwith("Invalid CURL_SSH_KEYFUNCTION argument");
         break;
     }
 
-    if (!Is_exception_result(result)) {
-      switch (Int_val(result)) {
+    v_found = ml_copy_string(foundkey->key, foundkey->len ? foundkey->len : strlen(foundkey->key));
+    v_result = caml_callback2_exn(Field(conn->ocamlValues, Ocaml_SSH_KEYFUNCTION), v_match, v_found);
+
+    if (!Is_exception_result(v_result)) {
+      switch (Int_val(v_result)) {
         case 0:
           res = CURLKHSTAT_FINE_ADD_TO_FILE;
           break;

--- a/curl-helper.c
+++ b/curl-helper.c
@@ -2847,18 +2847,7 @@ static void handle_POSTREDIR(Connection *conn, value option)
 }
 #endif
 
-static void handle_SSH_KNOWNHOSTS(Connection *conn, value option)
-{
-    CAMLparam1(option);
-    CURLcode result = CURLE_OK;
-
-    result = curl_easy_setopt(conn->handle, CURLOPT_SSH_KNOWNHOSTS, String_val(option));
-
-    if (result != CURLE_OK)
-        raiseError(conn, result);
-
-    CAMLreturn0;
-}
+SETOPT_VAL( SSH_KNOWNHOSTS, String_val)
 
 /**
  **  curl_easy_setopt helper function

--- a/curl.ml
+++ b/curl.ml
@@ -265,6 +265,17 @@ type curlMIMEPart =
     data: curlMIMEPartData;
   }
 
+type curlKHMatch =
+  | CURLKHMATCH_OK
+  | CURLKHMATCH_MISMATCH of string
+  | CURLKHMATCH_MISSING
+
+type curlKHStat =
+  | CURLKHSTAT_FINE_ADD_TO_FILE
+  | CURLKHSTAT_FINE
+  | CURLKHSTAT_REJECT
+  | CURLKHSTAT_DEFER
+
 (** Protocols to enable (via CURLOPT_PROTOCOLS and CURLOPT_REDIR_PROTOCOLS) *)
 type curlProto =
 | CURLPROTO_ALL (** enable everything *)
@@ -445,6 +456,8 @@ type curlOption =
   | CURLOPT_CONNECT_TO of string list
   | CURLOPT_POSTREDIR of curlPostRedir list
   | CURLOPT_MIMEPOST of curlMIMEPart list
+  | CURLOPT_SSHKNOWNHOSTS of string
+  | CURLOPT_SSHKEYFUNCTION of (curlKHMatch -> string -> curlKHStat)
 
 type initOption =
   | CURLINIT_GLOBALALL
@@ -970,6 +983,12 @@ let set_postredir conn l =
 let set_mimepost conn part =
   setopt conn (CURLOPT_MIMEPOST part)
 
+let set_sshknownhosts conn s =
+  setopt conn (CURLOPT_SSHKNOWNHOSTS s)
+
+let set_sshkeyfunction conn f =
+  setopt conn (CURLOPT_SSHKEYFUNCTION f)
+
 let get_effectiveurl conn =
   match (getinfo conn CURLINFO_EFFECTIVE_URL) with
   | CURLINFO_String s -> s
@@ -1305,6 +1324,8 @@ class handle =
     method set_opensocketfunction closure = set_opensocketfunction conn closure
     method set_proxytype t = set_proxytype conn t
     method set_mimepost p = set_mimepost conn p
+    method set_sshknownhosts s = set_sshknownhosts conn s
+    method set_sshkeyfunction f = set_sshkeyfunction conn f
 
     method get_effectiveurl = get_effectiveurl conn
     method get_redirecturl = get_redirecturl conn

--- a/curl.mli
+++ b/curl.mli
@@ -273,6 +273,17 @@ type curlMIMEPart =
     data: curlMIMEPartData;
   }
 
+type curlKHMatch =
+  | CURLKHMATCH_OK
+  | CURLKHMATCH_MISMATCH of string (* Base64-encoded *)
+  | CURLKHMATCH_MISSING
+
+type curlKHStat =
+  | CURLKHSTAT_FINE_ADD_TO_FILE
+  | CURLKHSTAT_FINE
+  | CURLKHSTAT_REJECT
+  | CURLKHSTAT_DEFER
+
 (** Protocols to enable (via CURLOPT_PROTOCOLS and CURLOPT_REDIR_PROTOCOLS) *)
 type curlProto =
 | CURLPROTO_ALL (** enable everything *)
@@ -453,6 +464,8 @@ type curlOption =
   | CURLOPT_CONNECT_TO of string list
   | CURLOPT_POSTREDIR of curlPostRedir list
   | CURLOPT_MIMEPOST of curlMIMEPart list (* @since libcurl 7.56.0 *)
+  | CURLOPT_SSHKNOWNHOSTS of string
+  | CURLOPT_SSHKEYFUNCTION of (curlKHMatch -> string (* raw *) -> curlKHStat)
 
 type initOption =
   | CURLINIT_GLOBALALL
@@ -717,6 +730,9 @@ val set_postredir : t -> curlPostRedir list -> unit
 val set_mimepost : t -> curlMIMEPart list -> unit
 (** @since 0.8.2 *)
 
+val set_sshknownhosts : t -> string -> unit
+val set_sshkeyfunction : t -> (curlKHMatch -> string -> curlKHStat) -> unit
+
 (** {2 Get transfer properties} *)
 
 val get_effectiveurl : t -> string
@@ -903,6 +919,8 @@ class handle :
     method set_resolve : (string * int * string) list -> (string * int) list -> unit
     method set_dns_servers : string list -> unit
     method set_mimepost : curlMIMEPart list -> unit
+    method set_sshknownhosts : string -> unit
+    method set_sshkeyfunction : (curlKHMatch -> string -> curlKHStat) -> unit
 
     method get_effectiveurl : string
     method get_redirecturl : string

--- a/curl.mli
+++ b/curl.mli
@@ -275,7 +275,9 @@ type curlMIMEPart =
 
 type curlKHMatch =
   | CURLKHMATCH_OK
-  | CURLKHMATCH_MISMATCH of string (* Base64-encoded *)
+  | CURLKHMATCH_MISMATCH of string
+  (** Argument consists of the base64-encoded public key of the remote host as
+      as found in the "known hosts" file **)
   | CURLKHMATCH_MISSING
 
 type curlKHStat =
@@ -465,7 +467,10 @@ type curlOption =
   | CURLOPT_POSTREDIR of curlPostRedir list
   | CURLOPT_MIMEPOST of curlMIMEPart list (* @since libcurl 7.56.0 *)
   | CURLOPT_SSHKNOWNHOSTS of string
-  | CURLOPT_SSHKEYFUNCTION of (curlKHMatch -> string (* raw *) -> curlKHStat)
+  | CURLOPT_SSHKEYFUNCTION of (curlKHMatch -> string -> curlKHStat)
+  (** The second argument to the passed function consists of the raw bytes of
+      the public key sent by the remote host. If the function raises an
+      exception the key will be rejected, and the connection will fail.**)
 
 type initOption =
   | CURLINIT_GLOBALALL


### PR DESCRIPTION
This PR is an initial try at adding support for the [`CURLOPT_SSH_KNOWNHOSTS`](https://curl.haxx.se/libcurl/c/CURLOPT_SSH_KNOWNHOSTS.html) and [`CURLOPT_SSH_KEYFUNCTION`](https://curl.haxx.se/libcurl/c/CURLOPT_SSH_KEYFUNCTION.html) options.
