### PR TITLE
Add OCaml 4.10 to the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - OCAML_VERSION=4.07
   - OCAML_VERSION=4.08
   - OCAML_VERSION=4.09
-  - OCAML_VERSION=4.10.0+rc2 OCAML_BETA=enable
+  - OCAML_VERSION=4.10
 os:
   - osx
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - OCAML_VERSION=4.07
   - OCAML_VERSION=4.08
   - OCAML_VERSION=4.09
+  - OCAML_VERSION=4.10.0+rc2 OCAML_BETA=enable
 os:
   - osx
   - linux


### PR DESCRIPTION
This adds OCaml 4.10 to the CI.

The final release for OCaml 4.10 is expected next week. Are there plans to make a release of ocurl soon?