### PR TITLE
Make it possible to add a name to a MIME part

### DIFF
--- a/curl.ml
+++ b/curl.ml
@@ -247,9 +247,18 @@ type curlProxyType =
   | CURLPROXY_SOCKS4A (** added in 7.18.0 *)
   | CURLPROXY_SOCKS5_HOSTNAME (** added in 7.18.0 *)
 
+type data_source =
+  | String of string (** Equivalent to `CURLMIME_DATA` *)
+  | File of string  (** Equivalent to `CURLMIME_FILEDATA` *)
+
 type curlMIMEPartData =
   | CURLMIME_DATA of string
   | CURLMIME_FILEDATA of string
+  | CURLMIME_DATA_WITH_NAME of {
+      data: data_source;
+      name: string option;
+      filename: string option;
+    }
 
 type curlMIMEEncoding =
   | CURLMIME_8BIT

--- a/curl.mli
+++ b/curl.mli
@@ -255,9 +255,18 @@ type curlProxyType =
   | CURLPROXY_SOCKS4A (** since libcurl 7.18.0 *)
   | CURLPROXY_SOCKS5_HOSTNAME (** since libcurl 7.18.0 *)
 
+type data_source =
+  | String of string (** Equivalent to `CURLMIME_DATA` *)
+  | File of string  (** Equivalent to `CURLMIME_FILEDATA` *)
+
 type curlMIMEPartData =
   | CURLMIME_DATA of string
   | CURLMIME_FILEDATA of string
+  | CURLMIME_DATA_WITH_NAME of {
+      data: data_source;
+      name: string option;
+      filename: string option;
+    }
 
 type curlMIMEEncoding =
   | CURLMIME_8BIT

--- a/examples/test_memory_leaks.ml
+++ b/examples/test_memory_leaks.ml
@@ -17,6 +17,23 @@ let test2 size =
   cleanup h;
   cleanup g
 
+let test3 size =
+  let h = init () in
+  let s = String.make size 'a' in
+  set_mimepost
+    h
+    [
+      {
+        encoding=CURLMIME_BINARY;
+        headers=[];
+        subparts=[];
+        data=CURLMIME_DATA_WITH_NAME {data=String s;name=Some "foo";filename=Some "bar"};
+      }
+    ];
+  let g = init () in
+  cleanup h;
+  cleanup g
+
 let rss () =
   let path = Printf.sprintf "/proc/%d/statm" (Unix.getpid ()) in
   try
@@ -40,4 +57,5 @@ let () =
   let mb = 1024 * 1024 in
   check test1 200 mb;
   check test2 100 mb;
+  check test3 100 mb;
   ()


### PR DESCRIPTION
This adds a field `name` of type `string option` to `curlMIMEPart`.  If
`name` is `Some str`, the library uses `curl_mime_name` to give the part
a name.

This enables the use of the library for uploading to S3 while avoiding
the deprecated `curl_form*` functions.