### PR TITLE
Add support for curl_multi_poll

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -3,6 +3,9 @@
 /* Define to 1 if you have the <curl/curl.h> header file. */
 #undef HAVE_CURL_CURL_H
 
+/* Does libcurl define curl_multi_poll */
+#undef HAVE_CURL_MULTI_POLL
+
 /* Define to 1 if you have the declaration of `CURLE_ABORTED_BY_CALLBACK', and
    to 0 if you don't. */
 #undef HAVE_DECL_CURLE_ABORTED_BY_CALLBACK
@@ -1130,6 +1133,10 @@
 /* Define to 1 if you have the declaration of `CURL_HTTP_VERSION_3', and to 0
    if you don't. */
 #undef HAVE_DECL_CURL_HTTP_VERSION_3
+
+/* Define to 1 if you have the declaration of `curl_multi_poll', and to 0 if
+   you don't. */
+#undef HAVE_DECL_CURL_MULTI_POLL
 
 /* Define to 1 if you have the declaration of `CURL_SSLVERSION_TLSv1_0', and
    to 0 if you don't. */

--- a/configure
+++ b/configure
@@ -8519,6 +8519,26 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 
 
+ac_fn_c_check_decl "$LINENO" "curl_multi_poll" "ac_cv_have_decl_curl_multi_poll" "
+#include \"curl/curl.h\"
+
+"
+if test "x$ac_cv_have_decl_curl_multi_poll" = xyes; then :
+  ac_have_decl=1
+else
+  ac_have_decl=0
+fi
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_CURL_MULTI_POLL $ac_have_decl
+_ACEOF
+if test $ac_have_decl = 1; then :
+
+$as_echo "#define HAVE_CURL_MULTI_POLL 1" >>confdefs.h
+
+fi
+
+
 ac_config_headers="$ac_config_headers config.h"
 
 ac_config_files="$ac_config_files Makefile examples/Makefile"

--- a/configure.ac
+++ b/configure.ac
@@ -194,6 +194,14 @@ CURL_VERSION_TLSAUTH_SRP, CURL_VERSION_NTLM_WB],
 #include "curl/curl.h"
 ])
 
+AC_CHECK_DECLS(
+[curl_multi_poll],
+AC_DEFINE([HAVE_CURL_MULTI_POLL], [1], [Does libcurl define curl_multi_poll]),
+[],
+[
+#include "curl/curl.h"
+])
+
 AC_CONFIG_HEADERS(config.h)
 AC_CONFIG_FILES([Makefile examples/Makefile])
 

--- a/curl-helper.c
+++ b/curl-helper.c
@@ -4240,6 +4240,27 @@ value caml_curl_multi_wait(value v_timeout_ms, value v_multi)
   CAMLreturn(Val_bool(numfds != 0));
 }
 
+value caml_curl_multi_poll(value v_timeout_ms, value v_multi)
+{
+  CAMLparam2(v_timeout_ms,v_multi);
+  CURLM *multi_handle = CURLM_val(v_multi);
+  int timeout_ms = Int_val(v_timeout_ms);
+  int numfds = -1;
+  CURLMcode rc;
+
+  caml_enter_blocking_section();
+#ifdef HAVE_CURL_MULTI_POLL
+  rc = curl_multi_poll(multi_handle, NULL, 0, timeout_ms, &numfds);
+#else
+  rc = curl_multi_wait(multi_handle, NULL, 0, timeout_ms, &numfds);
+#endif
+  caml_leave_blocking_section();
+
+  check_mcode("curl_multi_poll",rc);
+
+  CAMLreturn(Val_bool(numfds != 0));
+}
+
 value caml_curl_multi_add_handle(value v_multi, value v_easy)
 {
   CAMLparam2(v_multi,v_easy);

--- a/curl.ml
+++ b/curl.ml
@@ -1414,6 +1414,8 @@ module Multi = struct
   external perform : mt -> int = "caml_curl_multi_perform_all"
   external wait : int -> mt -> bool = "caml_curl_multi_wait"
   let wait ?(timeout_ms=1000) mt = wait timeout_ms mt
+  external poll : int -> mt -> bool = "caml_curl_multi_poll"
+  let poll ?(timeout_ms=1000) mt = poll timeout_ms mt
   external remove : mt -> t -> unit = "caml_curl_multi_remove_handle"
   external remove_finished : mt -> (t * curlCode) option = "caml_curlm_remove_finished"
   external cleanup : mt -> unit = "caml_curl_multi_cleanup"

--- a/curl.mli
+++ b/curl.mli
@@ -1017,6 +1017,13 @@ module Multi : sig
       @return whether [perform] should be called *)
   val wait : ?timeout_ms:int -> mt -> bool
 
+  (** poll till there are some active data transfers on multi stack.
+      Contrary to [wait], this function does not return immediately
+      when there are no pending transfer but waits for [timeout_ms]
+      The module falls back to [wait] if this function is unavailable.
+      @return whether [perform] should be called *)
+  val poll : ?timeout_ms:int -> mt -> bool
+
   (** remove finished handle from the multi stack if any. The returned handle may be reused *)
   val remove_finished : mt -> (t * curlCode) option
 


### PR DESCRIPTION
Contrary to `wait`, this function does not return immediately when there are no pending transfer but waits for `timeout_ms`. The module falls back to `wait` if the function is unavailable.