### PR TITLE
Directly create Curl.Multi.CError exception value

### DIFF
--- a/curl-helper.c
+++ b/curl-helper.c
@@ -4107,13 +4107,14 @@ static void raise_multi_cerror(char const* func, CURLMcode code)
     if (NULL == exception) caml_invalid_argument("Curl.Multi.CError");
   }
 
-  data = caml_alloc_tuple(3);
+  data = caml_alloc(4, 0);
 
-  Store_field(data, 0, caml_copy_string(func));
-  Store_field(data, 1, Val_int(code));
-  Store_field(data, 2, caml_copy_string(curl_multi_strerror(code)));
+  Store_field(data, 0, *exception);
+  Store_field(data, 1, caml_copy_string(func));
+  Store_field(data, 2, Val_int(code));
+  Store_field(data, 3, caml_copy_string(curl_multi_strerror(code)));
 
-  caml_raise_with_arg(*exception, data);
+  caml_raise(data);
 
   CAMLreturn0;
 }


### PR DESCRIPTION
`Curl.Multi.CError` is a value with multiple arguments, but it is currently created in `curl-helper.c` as if it were a value with a single tuple argument.

When I try to access the arguments at runtime, I encounter a segfault.

This PR constructs it as a multi-argument value in `curl-helper.c` to match the type in `curl.ml`.

An alternative approach would be to change the type of the exception from `exception CError of string * cerror * string` to `exception CError of (string * cerror * string)`;

On a related note, the `cerror` field is a shadowed type and I couldn't find any functions that operate on it. Is it intended to be that way? It seems like there is no way to make use of it right now.