### PR TITLE
Enable `configure` to generate `config.h` on Windows

### DIFF
--- a/configure
+++ b/configure
@@ -628,7 +628,6 @@ EXT_LIB
 EXT_DLL
 OCAML_HAS_BIN_ANNOT
 INSTALLDIR
-CURLLIBS
 ac_prefix_program
 OCAML_PKG_lwt_ppx
 OCAML_PKG_lwt_unix
@@ -650,6 +649,9 @@ OCAMLC
 INSTALL_DATA
 INSTALL_SCRIPT
 INSTALL_PROGRAM
+LIBCURL_VERSION
+CURLLIBS
+CURLCFLAGS
 OBJEXT
 EXEEXT
 ac_ct_CC
@@ -708,6 +710,9 @@ CFLAGS
 LDFLAGS
 LIBS
 CPPFLAGS
+CURLCFLAGS
+CURLLIBS
+LIBCURL_VERSION
 CPP'
 
 
@@ -1333,6 +1338,10 @@ Some influential environment variables:
   LIBS        libraries to pass to the linker, e.g. -l<library>
   CPPFLAGS    (Objective) C/C++ preprocessor flags, e.g. -I<include dir> if
               you have headers in a nonstandard directory <include dir>
+  CURLCFLAGS  libcurl C flags
+  CURLLIBS    libcurl library flags
+  LIBCURL_VERSION
+              libcurl version
   CPP         C preprocessor
 
 Use these variables to override the choices made by `configure' or to help
@@ -2840,36 +2849,48 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
+
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libcurl cflags" >&5
 $as_echo_n "checking for libcurl cflags... " >&6; }
-CURLCFLAGS=`pkg-config libcurl --cflags || curl-config --cflags`
-if  test "$?" -eq 0 ; then :
+if test -z "$CURLCFLAGS"; then :
+  CURLCFLAGS=`pkg-config libcurl --cflags || curl-config --cflags`
+   if  test "$?" -eq 0 ; then :
 
 else
   as_fn_error $? "libcurl was not found" "$LINENO" 5
+fi
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CURLCFLAGS" >&5
 $as_echo "$CURLCFLAGS" >&6; }
 
+
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libcurl libs" >&5
 $as_echo_n "checking for libcurl libs... " >&6; }
-CURLLIBS=`pkg-config libcurl --libs || curl-config --libs`
-if  test "$?" -eq 0 ; then :
+if test -z "$CURLLIBS"; then :
+  CURLLIBS=`pkg-config libcurl --libs || curl-config --libs`
+   if  test "$?" -eq 0 ; then :
 
 else
   as_fn_error $? "libcurl was not found" "$LINENO" 5
 fi
+fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CURLLIBS" >&5
 $as_echo "$CURLLIBS" >&6; }
 
+
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libcurl version >= $MIN_LIBCURL_VERSION" >&5
 $as_echo_n "checking for libcurl version >= $MIN_LIBCURL_VERSION... " >&6; }
-LIBCURL_VERSION=`pkg-config libcurl --modversion || curl-config --version`
-(pkg-config libcurl && pkg-config libcurl --atleast-version=${MIN_LIBCURL_VERSION}) || curl-config --checkfor ${MIN_LIBCURL_VERSION}
-if  test "$?" -eq 0 ; then :
+if test -z "$LIBCURL_VERSION"; then :
+  LIBCURL_VERSION=`pkg-config libcurl --modversion || curl-config --version`
+   (pkg-config libcurl && pkg-config libcurl --atleast-version=${MIN_LIBCURL_VERSION}) || curl-config --checkfor ${MIN_LIBCURL_VERSION}
+   if  test "$?" -eq 0 ; then :
 
 else
   as_fn_error $? "${LIBCURL_VERSION} is too old" "$LINENO" 5
+fi
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${LIBCURL_VERSION}" >&5
 $as_echo "${LIBCURL_VERSION}" >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -8,20 +8,29 @@ MIN_LIBCURL_VERSION=7.28.0
 
 AC_PROG_CC()
 
+AC_ARG_VAR([CURLCFLAGS], [libcurl C flags])
+
 AC_MSG_CHECKING([for libcurl cflags])
-CURLCFLAGS=`pkg-config libcurl --cflags || curl-config --cflags`
-AS_IF([ test "$?" -eq 0 ],,[AC_MSG_ERROR([libcurl was not found])] )
+AS_IF([test -z "$CURLCFLAGS"],
+  [CURLCFLAGS=`pkg-config libcurl --cflags || curl-config --cflags`
+   AS_IF([ test "$?" -eq 0 ],,[AC_MSG_ERROR([libcurl was not found])])])
 AC_MSG_RESULT([$CURLCFLAGS])
 
+AC_ARG_VAR([CURLLIBS], [libcurl library flags])
+
 AC_MSG_CHECKING([for libcurl libs])
-CURLLIBS=`pkg-config libcurl --libs || curl-config --libs`
-AS_IF([ test "$?" -eq 0 ],,[AC_MSG_ERROR([libcurl was not found])] )
+AS_IF([test -z "$CURLLIBS"],
+  [CURLLIBS=`pkg-config libcurl --libs || curl-config --libs`
+   AS_IF([ test "$?" -eq 0 ],,[AC_MSG_ERROR([libcurl was not found])])])
 AC_MSG_RESULT([$CURLLIBS])
 
+AC_ARG_VAR([LIBCURL_VERSION], [libcurl version])
+
 AC_MSG_CHECKING([for libcurl version >= $MIN_LIBCURL_VERSION])
-LIBCURL_VERSION=`pkg-config libcurl --modversion || curl-config --version`
-(pkg-config libcurl && pkg-config libcurl --atleast-version=${MIN_LIBCURL_VERSION}) || curl-config --checkfor ${MIN_LIBCURL_VERSION}
-AS_IF([ test "$?" -eq 0 ],,[AC_MSG_ERROR([${LIBCURL_VERSION} is too old])])
+AS_IF([test -z "$LIBCURL_VERSION"],
+  [LIBCURL_VERSION=`pkg-config libcurl --modversion || curl-config --version`
+   (pkg-config libcurl && pkg-config libcurl --atleast-version=${MIN_LIBCURL_VERSION}) || curl-config --checkfor ${MIN_LIBCURL_VERSION}
+   AS_IF([ test "$?" -eq 0 ],,[AC_MSG_ERROR([${LIBCURL_VERSION} is too old])])])
 AC_MSG_RESULT([${LIBCURL_VERSION}])
 
 AC_PROG_INSTALL()


### PR DESCRIPTION
Producing `config.h` for the Windows version of `libcurl` is an error-prone manual process. It would be nice to use `configure` for that.

To enable this I modified the `configure` script so that one can manually specify the variables `CURLCFLAGS`, `CURLLIBS` and `LIBCURL_VERSION`. **NB:** this is not enough to get a working `Makefile`, only to get an accurate `config.h`, so this feature should probably be left undocumented for the time being.

I tested with the official upstream Windows build of `libcurl`  https://curl.se/windows/ and the MSVC compiler.