### PR TITLE
Add missing dependency on Unix

### DIFF
--- a/dune
+++ b/dune
@@ -8,6 +8,7 @@
   (flags -DHAVE_CONFIG_H :standard)
   (names curl-helper))
  (c_library_flags (:include clibs.sexp))
+ (libraries unix)
  (modules curl))
 
 (library


### PR DESCRIPTION
Silences the alert proposed in ocaml/ocaml#11198, but this PR can be merged regardless.