### PR TITLE
Pass CURLCFLAGS to stub compilation

### DIFF
--- a/cflags.sexp.in
+++ b/cflags.sexp.in
@@ -1,0 +1,3 @@
+;; @configure_input@
+
+(@CURLCFLAGS@)

--- a/configure
+++ b/configure
@@ -6832,6 +6832,8 @@ ac_config_headers="$ac_config_headers config.h"
 
 ac_config_files="$ac_config_files clibs.sexp"
 
+ac_config_files="$ac_config_files cflags.sexp"
+
 ac_config_files="$ac_config_files Makefile"
 
 ac_config_files="$ac_config_files dune-project"
@@ -7523,6 +7525,7 @@ do
   case $ac_config_target in
     "config.h") CONFIG_HEADERS="$CONFIG_HEADERS config.h" ;;
     "clibs.sexp") CONFIG_FILES="$CONFIG_FILES clibs.sexp" ;;
+    "cflags.sexp") CONFIG_FILES="$CONFIG_FILES cflags.sexp" ;;
     "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;
     "dune-project") CONFIG_FILES="$CONFIG_FILES dune-project" ;;
 

--- a/configure.ac
+++ b/configure.ac
@@ -170,6 +170,7 @@ AC_CHECK_DECLS([curl_multi_poll, curl_global_sslset],
 
 AC_CONFIG_HEADERS(config.h)
 AC_CONFIG_FILES([clibs.sexp])
+AC_CONFIG_FILES([cflags.sexp])
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([dune-project])
 

--- a/dune
+++ b/dune
@@ -5,7 +5,7 @@
  (wrapped false)
  (foreign_stubs
   (language c)
-  (flags -DHAVE_CONFIG_H :standard)
+  (flags -DHAVE_CONFIG_H :standard (:include cflags.sexp))
   (names curl-helper))
  (c_library_flags (:include clibs.sexp))
  (libraries unix)


### PR DESCRIPTION
It looks like the path to the header files detected using pkg-config/curl-config is not actually used. So compilation doesn't work when headers are in non-standard locations.

This PR fixes that.