### PR TITLE
Bind `extra_fds` argument to `curl_multi_wait` and `curl_multi_poll`

### DIFF
--- a/curl-helper.c
+++ b/curl-helper.c
@@ -4730,38 +4730,115 @@ value caml_curlm_remove_finished(value v_multi)
   }
 }
 
-value caml_curl_multi_wait(value v_timeout_ms, value v_multi)
+static int curlWait_table[] = {
+  CURL_WAIT_POLLIN,
+  CURL_WAIT_POLLPRI,
+  CURL_WAIT_POLLOUT,
+};
+
+static int list_length(value v)
 {
-  CAMLparam2(v_timeout_ms,v_multi);
+  int n = 0;
+  while (v != Val_emptylist) {
+    n ++;
+    v = Field(v, 1);
+  }
+  return n;
+}
+
+static struct curl_waitfd *convert_extra_fds(value v_extra_fds, int *extra_nfds)
+{
+  struct curl_waitfd *extra_fds = NULL;
+  value v_extra_fd;
+  int i, nfds;
+
+  nfds = *extra_nfds = list_length(v_extra_fds);
+
+  if (nfds == 0) return NULL;
+
+  extra_fds = caml_stat_alloc(sizeof(extra_fds[0]) * nfds);
+
+  i = 0;
+  while (v_extra_fds != Val_emptylist) {
+    v_extra_fd = Field(v_extra_fds, 0);
+    extra_fds[i].fd = Socket_val(Field(v_extra_fd, 0));
+    extra_fds[i].events = caml_convert_flag_list(Field(v_extra_fd, 1), curlWait_table);
+    extra_fds[i].revents = 0;
+    i ++;
+    v_extra_fds = Field(v_extra_fds, 1);
+  }
+
+  return extra_fds;
+}
+
+/* Assumes v_extra_fds and extra_fds to have the same number of elements */
+static void update_extra_fds(value v_extra_fds, struct curl_waitfd *extra_fds)
+{
+  CAMLparam1(v_extra_fds);
+  CAMLlocal2(v_extra_fd, lst);
+  int i, j;
+
+  i = 0;
+  while (v_extra_fds != Val_emptylist) {
+    v_extra_fd = Field(v_extra_fds, 0);
+    for (j = 0, lst = Val_emptylist; j < sizeof(curlWait_table)/sizeof(curlWait_table[0]); j ++) {
+      if (curlWait_table[j] & extra_fds[i].revents)
+        lst = Val_cons(Val_int(j), lst);
+    }
+    Store_field(v_extra_fd, 2, lst);
+    i ++;
+    v_extra_fds = Field(v_extra_fds, 1);
+  }
+
+  CAMLreturn0;
+}
+
+value caml_curl_multi_wait(value v_timeout_ms, value v_extra_fds, value v_multi)
+{
+  CAMLparam3(v_timeout_ms,v_extra_fds,v_multi);
   CURLM *multi_handle = CURLM_val(v_multi);
   int timeout_ms = Int_val(v_timeout_ms);
   int numfds = -1;
+  int extra_nfds = 0;
+  struct curl_waitfd *extra_fds = convert_extra_fds(v_extra_fds, &extra_nfds);
   CURLMcode rc;
 
   caml_enter_blocking_section();
-  rc = curl_multi_wait(multi_handle, NULL, 0, timeout_ms, &numfds);
+  rc = curl_multi_wait(multi_handle, extra_fds, extra_nfds, timeout_ms, &numfds);
   caml_leave_blocking_section();
+
+  if (extra_fds != NULL) {
+    update_extra_fds(v_extra_fds, extra_fds);
+    caml_stat_free(extra_fds);
+  }
 
   check_mcode("curl_multi_wait",rc);
 
   CAMLreturn(Val_bool(numfds != 0));
 }
 
-value caml_curl_multi_poll(value v_timeout_ms, value v_multi)
+value caml_curl_multi_poll(value v_timeout_ms, value v_extra_fds, value v_multi)
 {
-  CAMLparam2(v_timeout_ms,v_multi);
+  CAMLparam3(v_timeout_ms,v_extra_fds,v_multi);
   CURLM *multi_handle = CURLM_val(v_multi);
   int timeout_ms = Int_val(v_timeout_ms);
   int numfds = -1;
+  int extra_nfds = 0;
+  struct curl_waitfd *extra_fds = convert_extra_fds(v_extra_fds, &extra_nfds);
   CURLMcode rc;
 
   caml_enter_blocking_section();
 #if HAVE_DECL_CURL_MULTI_POLL
-  rc = curl_multi_poll(multi_handle, NULL, 0, timeout_ms, &numfds);
+  rc = curl_multi_poll(multi_handle, extra_fds, extra_nfds, timeout_ms, &numfds);
 #else
-  rc = curl_multi_wait(multi_handle, NULL, 0, timeout_ms, &numfds);
+  rc = curl_multi_wait(multi_handle, extra_fds, extra_nfds, timeout_ms, &numfds);
 #endif
   caml_leave_blocking_section();
+
+  if (extra_fds != NULL) {
+    update_extra_fds(v_extra_fds, extra_fds);
+    caml_stat_free(extra_fds);
+  }
 
   check_mcode("curl_multi_poll",rc);
 

--- a/curl.ml
+++ b/curl.ml
@@ -1504,18 +1504,35 @@ module Multi = struct
 
   type cerror = int
 
+  let int_of_cerror err = err
+
   exception CError of string * cerror * string
 
   let () = Callback.register_exception "Curl.Multi.Error" (Error "")
   let () = Callback.register_exception "Curl.Multi.CError" (CError ("",0,""))
 
+  type waitfd_event =
+    | CURL_WAIT_POLLIN
+    | CURL_WAIT_POLLPRI
+    | CURL_WAIT_POLLOUT
+
+  type waitfd = {
+    fd: Unix.file_descr;
+    events: waitfd_event list;
+    mutable revents: waitfd_event list;
+  }
+
+  let waitfd fd events = {fd; events; revents = []}
+  let waitfd_fd fd = fd.fd
+  let waitfd_isset fd event = List.mem event fd.revents
+
   external create : unit -> mt = "caml_curl_multi_init"
   external add : mt -> t -> unit = "caml_curl_multi_add_handle"
   external perform : mt -> int = "caml_curl_multi_perform_all"
-  external wait : int -> mt -> bool = "caml_curl_multi_wait"
-  let wait ?(timeout_ms=1000) mt = wait timeout_ms mt
-  external poll : int -> mt -> bool = "caml_curl_multi_poll"
-  let poll ?(timeout_ms=1000) mt = poll timeout_ms mt
+  external wait : int -> waitfd list -> mt -> bool = "caml_curl_multi_wait"
+  let wait ?(timeout_ms=1000) ?(extra_fds = []) mt = wait timeout_ms extra_fds mt
+  external poll : int -> waitfd list -> mt -> bool = "caml_curl_multi_poll"
+  let poll ?(timeout_ms=1000) ?(extra_fds = []) mt = poll timeout_ms extra_fds mt
   external remove : mt -> t -> unit = "caml_curl_multi_remove_handle"
   external remove_finished : mt -> (t * curlCode) option = "caml_curlm_remove_finished"
   external cleanup : mt -> unit = "caml_curl_multi_cleanup"


### PR DESCRIPTION
Propose to bind the `extra_fds` argument of [`curl_multi_wait`](https://curl.se/libcurl/c/curl_multi_wait.html) and [`curl_multi_poll`](https://curl.se/libcurl/c/curl_multi_poll.html).

Suggestions to improve the API are welcome!