### PR TITLE
feature: split lwt package

### DIFF
--- a/curl_lwt.opam
+++ b/curl_lwt.opam
@@ -30,5 +30,5 @@ depends: [
   "lwt"
   "lwt_ppx"
 ]
-synopsis: "Bindings to Ltw"
+synopsis: "Bindings to Lwt"
 description: "libcurl is a client-side URL transfer library, supporting HTTP and a multitude of other network protocols (FTP/SMTP/RTSP/etc). This library wrap easy synchronous API (Curl), synchronous parallel and generic asynchronous API (Curl.Multi), and provides an Lwt-enabled asynchronous interface (Curl_lwt)."

--- a/curl_lwt.opam
+++ b/curl_lwt.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-name: "curl"
+name: "curl_lwt"
 maintainer: "ygrek@autistici.org"
 homepage: "https://ygrek.org/p/ocurl"
 license: "MIT"
@@ -9,7 +9,6 @@ dev-repo: "git+https://github.com/ygrek/ocurl.git"
 bug-reports: "https://github.com/ygrek/ocurl/issues"
 tags: ["org:ygrek" "clib:curl"]
 build: [
-  ["./configure"]
   [
     "dune"
     "build"
@@ -27,7 +26,9 @@ depends: [
   "dune" {>= "2.8"}
   "odoc" {with-doc}
   "base-unix"
-  "conf-libcurl"
+  "curl" {= version}
+  "lwt"
+  "lwt_ppx"
 ]
-synopsis: "Bindings to libcurl"
+synopsis: "Bindings to Ltw"
 description: "libcurl is a client-side URL transfer library, supporting HTTP and a multitude of other network protocols (FTP/SMTP/RTSP/etc). This library wrap easy synchronous API (Curl), synchronous parallel and generic asynchronous API (Curl.Multi), and provides an Lwt-enabled asynchronous interface (Curl_lwt)."

--- a/dune
+++ b/dune
@@ -13,8 +13,11 @@
 
 (library
  (name curl_lwt)
- (public_name curl.lwt)
- (optional)
+ (public_name curl_lwt)
  (wrapped false)
  (libraries curl lwt.unix)
  (modules curl_lwt))
+
+(deprecated_library_name
+ (old_public_name curl.lwt)
+ (new_public_name curl_lwt))


### PR DESCRIPTION
Split curl.lwt into its own package.

This allows users to depend on lwt and curl without pulling in curl.lwt (cohttp-curl-lwt does that)

We leave a findlib alias from curl.lwt to curl_lwt so that users can transition easier.

cc @kit-ty-kate 