### PR TITLE
Call configure script from curl_lwt.opam

### DIFF
--- a/curl_lwt.opam
+++ b/curl_lwt.opam
@@ -9,6 +9,7 @@ dev-repo: "git+https://github.com/ygrek/ocurl.git"
 bug-reports: "https://github.com/ygrek/ocurl/issues"
 tags: ["org:ygrek" "clib:curl"]
 build: [
+  ["./configure"]
   [
     "dune"
     "build"


### PR DESCRIPTION
Without this change, `opam install curl_lwt` fails:

~~~
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
⬇ retrieved curl_lwt.~dev  (no changes)
[ERROR] The compilation of curl_lwt.~dev failed at "dune build -p curl_lwt -j 31 @install".

#=== ERROR while compiling curl_lwt.~dev ======================================#
# context     2.1.5 | linux/x86_64 | ocaml-base-compiler.5.2.0 | pinned(git+https://github.com/ygrek/ocurl#1bc75b8314575929450d378c0b156e686edc420c#1bc75b8314575929450d378c0b156e686edc420c)
# path        ~/.opam/ocaml-base-compiler.5.2.0/.opam-switch/build/curl_lwt.~dev
# command     ~/.opam/opam-init/hooks/sandbox.sh build dune build -p curl_lwt -j 31 @install
# exit-code   1
# env-file    ~/.opam/log/curl_lwt-2122965-d83b2c.env
# output-file ~/.opam/log/curl_lwt-2122965-d83b2c.out
### output ###
# File ".", line 1, characters 0-0:
# Error: No dune-project file has been found in directory ".". A default one is
# assumed but the project might break when dune is upgraded. Please create a
# dune-project file.
# Hint: generate the project file with: $ dune init project <name>
~~~