### PR TITLE
Implement CURLOPT_CLOSESOCKETFUNCTION

### DIFF
--- a/curl-helper.c
+++ b/curl-helper.c
@@ -106,7 +106,6 @@ typedef enum OcamlValues
     Ocaml_IOCTLFUNCTION,
     Ocaml_SEEKFUNCTION,
     Ocaml_OPENSOCKETFUNCTION,
-    /* Ocaml_CLOSESOCKETFUNCTION, */
     Ocaml_SSH_KEYFUNCTION,
 
     Ocaml_ERRORBUFFER,
@@ -1217,29 +1216,6 @@ static int cb_OPENSOCKETFUNCTION(void *data,
     return ((sock == -1) ? CURL_SOCKET_BAD : sock);
 }
 
-/*
-static int cb_CLOSESOCKETFUNCTION(void *data,
-                         curl_socket_t socket)
-{
-    caml_leave_blocking_section();
-
-    CAMLparam0();
-    CAMLlocal1(camlResult);
-    Connection *conn = (Connection *)data;
-    int result = 0;
-
-    camlResult = caml_callback_exn(Field(conn->ocamlValues, Ocaml_CLOSESOCKETFUNCTION), Val_int(socket));
-    if (Is_exception_result(camlResult))
-    {
-      result = 1;
-    }
-    CAMLdrop;
-
-    caml_enter_blocking_section();
-    return result;
-}
-*/
-
 static int cb_SSH_KEYFUNCTION(CURL *easy,
                               const struct curl_khkey *knownkey,
                               const struct curl_khkey *foundkey,
@@ -1617,7 +1593,6 @@ SETOPT_FUNCTION( IOCTL)
 #endif
 
 SETOPT_FUNCTION( OPENSOCKET)
-/* SETOPT_FUNCTION( CLOSESOCKET) */
 
 static void handle_slist(Connection *conn, struct curl_slist** slist, CURLoption curl_option, value option)
 {
@@ -3671,7 +3646,6 @@ CURLOptionMapping implementedOptionMap[] =
   HAVENOT(AUTOREFERER),
 #endif
   HAVE(OPENSOCKETFUNCTION),
-  /*HAVE(CLOSESOCKETFUNCTION),*/
 #if HAVE_DECL_CURLOPT_PROXYTYPE
   HAVE(PROXYTYPE),
 #else
@@ -4580,6 +4554,7 @@ enum
 {
   curlmopt_socket_function,
   curlmopt_timer_function,
+  curlmopt_closesocket_function,
 
   /* last, not used */
   multi_values_total
@@ -4862,12 +4837,43 @@ value caml_curl_multi_poll(value v_timeout_ms, value v_extra_fds, value v_multi)
   CAMLreturn(Val_bool(numfds != 0));
 }
 
+static int curlm_closesocket_cb(void *data, curl_socket_t socket)
+{
+  caml_leave_blocking_section();
+
+  CAMLparam0();
+  CAMLlocal1(camlResult);
+
+  ml_multi_handle* multi = (ml_multi_handle*)data;
+  int result = 0;
+  camlResult = caml_callback_exn(Field(multi->values, curlmopt_closesocket_function), Val_socket(socket));
+  if (Is_exception_result(camlResult))
+  {
+    result = 1;
+  }
+  CAMLdrop;
+
+  caml_enter_blocking_section();
+  return result;
+}
+
 value caml_curl_multi_add_handle(value v_multi, value v_easy)
 {
   CAMLparam2(v_multi,v_easy);
   CURLMcode rc = CURLM_OK;
   CURLM* multi = CURLM_val(v_multi);
   Connection* conn = Connection_val(v_easy);
+
+  if (Field(Multi_val(v_multi)->values, curlmopt_closesocket_function) != Val_unit)
+  {
+    CURLcode result = CURLE_OK;
+    result = curl_easy_setopt(conn->handle, CURLOPT_CLOSESOCKETDATA, Multi_val(v_multi));
+    if (result != CURLE_OK)
+      raiseError(conn, result);
+    result = curl_easy_setopt(conn->handle, CURLOPT_CLOSESOCKETFUNCTION, curlm_closesocket_cb);
+    if (result != CURLE_OK)
+      raiseError(conn, result);
+  }
 
   /* prevent collection of OCaml value while the easy handle is used
    and may invoke callbacks registered on OCaml side */
@@ -5061,6 +5067,16 @@ value caml_curl_multi_timerfunction(value v_multi, value v_cb)
 
   curl_multi_setopt(multi->handle, CURLMOPT_TIMERFUNCTION, curlm_timer_cb);
   curl_multi_setopt(multi->handle, CURLMOPT_TIMERDATA, multi);
+
+  CAMLreturn(Val_unit);
+}
+
+value caml_curl_multi_closesocketfunction(value v_multi, value v_cb)
+{
+  CAMLparam2(v_multi, v_cb);
+  ml_multi_handle* multi = Multi_val(v_multi);
+
+  Store_field(multi->values, curlmopt_closesocket_function, v_cb);
 
   CAMLreturn(Val_unit);
 }

--- a/curl.ml
+++ b/curl.ml
@@ -1560,6 +1560,7 @@ module Multi = struct
 
   external set_socket_function : mt -> (Unix.file_descr -> poll -> unit) -> unit = "caml_curl_multi_socketfunction"
   external set_timer_function : mt -> (int -> unit) -> unit = "caml_curl_multi_timerfunction"
+  external set_closesocket_function : mt -> (Unix.file_descr -> unit) -> unit = "caml_curl_multi_closesocketfunction"
   external action_all : mt -> int = "caml_curl_multi_socket_all"
   external socket_action : mt -> Unix.file_descr option -> fd_status -> int = "caml_curl_multi_socket_action"
 

--- a/curl.mli
+++ b/curl.mli
@@ -478,7 +478,6 @@ type curlOption =
   | CURLOPT_SEEKFUNCTION of (int64 -> curlSeek -> curlSeekResult)
   | CURLOPT_AUTOREFERER of bool
   | CURLOPT_OPENSOCKETFUNCTION of (Unix.file_descr -> unit)
-(*   | CURLOPT_CLOSESOCKETFUNCTION of (Unix.file_descr -> unit) *)
   | CURLOPT_PROXYTYPE of curlProxyType
   | CURLOPT_PROTOCOLS of curlProto list
   | CURLOPT_REDIR_PROTOCOLS of curlProto list
@@ -807,11 +806,6 @@ val set_opensocketfunction : t -> (Unix.file_descr -> unit) -> unit
 val set_tcpkeepalive : t -> bool -> unit
 val set_tcpkeepidle : t -> int -> unit
 val set_tcpkeepintvl : t -> int -> unit
-
-(** current implementation is faulty
-    ref https://github.com/ygrek/ocurl/issues/58
-val set_closesocketfunction : t -> (Unix.file_descr -> unit) -> unit
-*)
 val set_proxytype : t -> curlProxyType -> unit
 val set_protocols : t -> curlProto list -> unit
 val set_redirprotocols : t -> curlProto list -> unit
@@ -1046,7 +1040,6 @@ class handle :
     method set_seekfunction : (int64 -> curlSeek -> curlSeekResult) -> unit
     method set_autoreferer : bool -> unit
     method set_opensocketfunction : (Unix.file_descr -> unit) -> unit
-(*     method set_closesocketfunction : (Unix.file_descr -> unit) -> unit *)
     method set_proxytype : curlProxyType -> unit
     method set_resolve : (string * int * string) list -> (string * int) list -> unit
     method set_dns_servers : string list -> unit
@@ -1194,6 +1187,14 @@ module Multi : sig
 
       NB {!action_timeout} should be called when timeout occurs *)
   val set_timer_function : mt -> (int -> unit) -> unit
+
+  (** set a function to be called to close a socket.
+
+      The underlying callback is a property of the easy handle, but cannot be stored there
+      in these bindings because libcurl's use of this callback may occur outside the
+      lifetime of the easy handle. This means that all easy handles added to a multi
+      handle must use the same closesocket function. *)
+  val set_closesocket_function : mt -> (Unix.file_descr -> unit) -> unit
 
   (** perform pending data transfers (if any) on all handles currently in multi stack
       (not recommended, {!action} should be used instead)


### PR DESCRIPTION
Implement a close socket function for curl multi. There previously was an implementation that set this callback onto the easy handle but could result in segfaults.

I chose to place this onto the multi handle instead of providing a global callback for (possible) better future compatibility with multicore OCaml.

Fixes #58 