### PR TITLE
fix case fallthrough on CURLFTPMETHOD_SINGLECWD

### DIFF
--- a/curl-helper.c
+++ b/curl-helper.c
@@ -2907,6 +2907,7 @@ static void handle_FTP_FILEMETHOD(Connection *conn, value option)
         result = curl_easy_setopt(conn->handle,
                                   CURLOPT_FTP_FILEMETHOD,
                                   CURLFTPMETHOD_SINGLECWD);
+        break;
 
     default:
         caml_failwith("Invalid FTP_FILEMETHOD value");


### PR DESCRIPTION
Should there be a `break;` after the case for CURLFTPMETHOD_SINGLECWD?

I don't use this code but got a compiler warning that I did not like.