### PR TITLE
Use write function callback without copying data

### DIFF
--- a/curl.ml
+++ b/curl.ml
@@ -336,6 +336,7 @@ type 'a xfer_result = Proceed of 'a | Pause | Abort
 
 type write_result = unit xfer_result
 type read_result = string xfer_result
+type bigstring = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
 let proceed = Proceed ()
 
@@ -491,6 +492,7 @@ type curlOption =
   | CURLOPT_SSL_OPTIONS of curlSslOption list
   | CURLOPT_PROXY_SSL_OPTIONS of curlSslOption list
   | CURLOPT_WRITEFUNCTION2 of (string -> write_result)
+  | CURLOPT_WRITEFUNCTION_BUF of (bigstring -> write_result)
   | CURLOPT_READFUNCTION2 of (int -> read_result)
   | CURLOPT_XFERINFOFUNCTION of (int64 -> int64 -> int64 -> int64 -> bool)
   | CURLOPT_PREREQFUNCTION of (string -> string -> int -> int -> bool)
@@ -625,6 +627,7 @@ let errno = int_of_curlCode
 
 type pauseOption = PAUSE_SEND | PAUSE_RECV | PAUSE_ALL
 
+
 external pause : t -> pauseOption list -> unit = "caml_curl_pause"
 
 let set_writefunction conn closure =
@@ -632,6 +635,9 @@ let set_writefunction conn closure =
 
 let set_writefunction2 conn closure =
   setopt conn (CURLOPT_WRITEFUNCTION2 closure)
+
+let set_writefunction_buf conn closure =
+  setopt conn (CURLOPT_WRITEFUNCTION_BUF closure)
 
 let set_readfunction conn closure =
   setopt conn (CURLOPT_READFUNCTION closure)


### PR DESCRIPTION
This change provides an additional signature variation for CURLOPT_WRITEFUNCTION that invokes the callback without first copying buffer contents. This approximately doubles performance for workloads bound by throughput.

Detail:

In benchmarks I found that for HTTP payloads 512kB and over, nearly the entire cost of using libcurl is copying payloads into the application.

The intended use of the write function callback is (usually) for the application to accumulate chunks of data into an assembled payload. This (usually) requires copying the data on the application side, for example into a larger buffer.

Existing implementations of this callback in ocurl allocate and copy an OCaml string before invoking the callback, which then (likely) has to copy the data again. In this implementation we expose libcurl's buffer to the application so the allocation and copy can happen only once.

The downside of this signature is that it is possible to do unsafe things with the buffer, like access it outside of the callback or write to it. 