### PR TITLE
Release lock on cleanup because it might call callbacks

### DIFF
--- a/curl-helper.c
+++ b/curl-helper.c
@@ -4670,7 +4670,9 @@ value caml_curl_multi_cleanup(value handle)
 
   caml_remove_generational_global_root(&h->values);
 
+  caml_enter_blocking_section();
   CURLcode rc = curl_multi_cleanup(h->handle);
+  caml_leave_blocking_section();
 
   caml_stat_free(h);
   Multi_val(handle) = (ml_multi_handle*)NULL;


### PR DESCRIPTION
libcurl can call callbacks during cleanup, so release the lock on the cleanup call.

Discussion on libcurl mailing list

https://curl.se/mail/lib-2025-02/0065.html