### PR TITLE
Fix cast warning on clang

### DIFF
--- a/curl-helper.c
+++ b/curl-helper.c
@@ -713,7 +713,7 @@ static void removeConnection(Connection *connection, int finalization)
       {
         fin_url = "unknown";
       }
-      fprintf(stderr,"Curl: handle %p leaked, conn %p, url %s\n", connection->handle, connection, fin_url);
+      fprintf(stderr,"Curl: handle %p leaked, conn %p, url %s\n", connection->handle, (void *) connection, fin_url);
       fflush(stderr);
     }
     else


### PR DESCRIPTION
A very minor change that cleans up a warning when building with clang.