### PR TITLE
Depend on dune-configurator >= 3.18.1 for pkgconf fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,9 +43,7 @@ jobs:
           opam install conf-pkg-config
           opam install . --deps-only --with-test --with-dev-setup
 
-      - env:
-          PKG_CONFIG_PATH: /usr/x86_64-w64-mingw32/sys-root/mingw/lib/pkgconfig
-        run: opam exec -- dune build
+      - run: opam exec -- dune build
 
       - run: opam exec -- dune runtest
         if: ${{ runner.os != 'Windows' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
+      - name: Fix Cygwin
+        if: runner.os == 'Windows'
+        shell: bash -eo pipefail -o igncr {0}
+        run: sed -i -e 's/binary/noacl,&/' /etc/fstab
+
       - name: Install opam dependencies
         run: |
           # Work around https://github.com/ocaml/setup-ocaml/issues/899

--- a/curl.opam
+++ b/curl.opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/ygrek/ocurl/issues"
 depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.11"}
-  "dune-configurator"
+  "dune-configurator" {>= "3.18.1"}
   "base-bigarray"
   "base-unix"
   "conf-libcurl"

--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,7 @@
  (description "libcurl is a client-side URL transfer library, supporting HTTP and a multitude of other network protocols (FTP/SMTP/RTSP/etc). This library wrap easy synchronous API (Curl) and synchronous parallel and generic asynchronous API (Curl.Multi). For the Lwt-enabled asynchronous interface (Curl_lwt) see curl_lwt package.")
  (depends
   (ocaml (>= "4.11"))
-  dune-configurator
+  (dune-configurator (>= "3.18.1"))
   base-bigarray
   base-unix  
   conf-libcurl)


### PR DESCRIPTION
See:
- https://github.com/ocaml/dune/pull/11619
- https://github.com/ocaml/opam-repository/pull/27761

This does *not* necessarily bump the dune lower bound, as dune-configurator depends on `"dune" {>= "3.12"}`. The pkgconf patches help locating the correct libcurl when it has been installed by different toolchains.