### PR TITLE
[v2] Release lock on cleanup because it might call callbacks 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,6 +23,8 @@
 + Get a list of headers with [get_headers] that result from repeatedly calling
   [curl_easy_nextheader] with the supplied origins and request.
   (Luke Palmer)
+* Fix handling of the runtime lock when calling curl multi callback cleanups.
+  (Malcolm, review by ygrek, Nicolás Ojeda Bär, and Antonin Décimo)
 
 ## 0.9.2 - 7 Jan 2022
 

--- a/curl-helper.c
+++ b/curl-helper.c
@@ -4763,7 +4763,9 @@ value caml_curl_multi_cleanup(value handle)
 
   caml_remove_generational_global_root(&h->values);
 
+  caml_release_runtime_system();
   CURLMcode rc = curl_multi_cleanup(h->handle);
+  caml_acquire_runtime_system();
 
   caml_stat_free(h);
   Multi_val(handle) = (ml_multi_handle*)NULL;

--- a/curl-helper.c
+++ b/curl-helper.c
@@ -4761,11 +4761,11 @@ value caml_curl_multi_cleanup(value handle)
   if (NULL == h)
     CAMLreturn(Val_unit);
 
-  caml_remove_generational_global_root(&h->values);
-
   caml_release_runtime_system();
   CURLMcode rc = curl_multi_cleanup(h->handle);
   caml_acquire_runtime_system();
+
+  caml_remove_generational_global_root(&h->values);
 
   caml_stat_free(h);
   Multi_val(handle) = (ml_multi_handle*)NULL;


### PR DESCRIPTION
This PR completes #90. I start by replacing `caml_{enter,leave}_blocking_section` with `caml_{release,acquire}_runtime_system` for modernity and consistency. Then, we have @orbitz fix with a hopefully complete explanation (thanks to @gasche for the help understanding this); and finally the change moving the removal of the global tracking callbacks to after the cleanup callbacks have finished, as suggested by @ygrek and @nojb.

Curl multi callbacks are registered with the [`CURLMOPT_SOCKETFUNCTION`][1] option of [`curl_multi_setopt`][2]:

```c
curl_multi_setopt(multi->handle,
                  CURLMOPT_SOCKETFUNCTION,
                  curlm_sock_cb);
```

This `curlm_sock_cb` function is C code, that starts by acquiring the OCaml [runtime lock][3] so that it can execute an OCaml callback, then releases the runtime lock:

```c
static int curlm_sock_cb(CURL *e, curl_socket_t sock, int what,
                         void *cbp, void *sockp)
{
  caml_acquire_runtime_system();

  /* ... */

  caml_callback2(Field(((ml_multi_handle*)cbp)->values,
                 curlmopt_socket_function), csock, v_what);

  /* ... */

  caml_release_runtime_system();
  return 0;
}

```

It's good that these curl callback functions try to acquire the runtime lock because they can be called from a context where the lock isn't held.

During execution of `caml_curl_multi_cleanup`, the runtime lock is held. The `curl_multi_cleanup` function might call callbacks which try to acquire the runtime lock. As such, execution will block when the callback try to acquire the runtime lock.

This patch fixes the issue by releasing the runtime lock before curl callbacks are called, since they each try to acquire the lock.

[1]: https://curl.se/libcurl/c/CURLMOPT_SOCKETFUNCTION.html
[2]: https://curl.se/libcurl/c/curl_multi_setopt.html
[3]: https://ocaml.org/manual/5.3/intfc.html#ss:parallel-execution-long-running-c-code