### PR TITLE
GHA: remove some workarounds on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,20 +32,9 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
-      - name: Fix Cygwin
-        if: runner.os == 'Windows'
-        shell: bash -eo pipefail -o igncr {0}
-        run: sed -i -e 's/binary/noacl,&/' /etc/fstab
-
       - name: Install opam dependencies
-        run: |
-          # Work around https://github.com/ocaml/setup-ocaml/issues/899
-          opam install conf-pkg-config
-          opam install . --deps-only --with-test --with-dev-setup
+        run: opam install . --deps-only --with-test --with-dev-setup
 
       - run: opam exec -- dune build
 
       - run: opam exec -- dune runtest
-        if: ${{ runner.os != 'Windows' }}
-        # libcurl (and prob. others) need a rebuild after the OpenSSL 3 upgrade
-        # https://cygwin.com/pipermail/cygwin/2025-March/257664.html


### PR DESCRIPTION
- conf-libcurl now depends on mingw-w64-shims, fixing the dectection of the curl-config script; See https://github.com/ocaml-windows/papercuts/issues/12.
- Cygwin's x86_64-mingw32-libcurl now depends on OpenSSL 3.