### PR TITLE
Fix/remove incorrect rc decrement causing double free and leak reported

### DIFF
--- a/curl-helper.c
+++ b/curl-helper.c
@@ -4822,7 +4822,6 @@ value caml_curlm_remove_finished(value v_multi)
     {
         Store_field(Field(conn->ocamlValues, Ocaml_ERRORBUFFER), 0, caml_copy_string(conn->curl_ERRORBUFFER));
     }
-    conn->refcount--;
     /* NB: same handle, but different block */
     v_easy = caml_curl_alloc(conn);
     v_tuple = caml_alloc_tuple(2);


### PR DESCRIPTION
So I've been building a client for Picos using the multi socket api and I've been fighting double free and leaked handle errors for a week now. I finally narrowed it down to definitely being somewhere in the bindings/libcurl.

I'm sure this function is the culprit:

So rough overview:
1. we make a handle rc=1 handles=1
2. we add the handle to the multi rc=2 handles=1
3. we call remove_finished rc=2 handles=2
4. we remove the handle from the multi rc=1 handles=2
6. the second handle goes out of scope and gets gced rc=0 handles=1 LEAK REPORTED
6. We clean up the original handle rc= 0 handles=1 
7. the og handle goes out of scope. DOUBLE FREE (memory corruption/ crash if run in valgrind)
 
```ocaml
value caml_curlm_remove_finished(value v_multi)
{
  CAMLparam1(v_multi);
  CAMLlocal2(v_easy, v_tuple);
  CURL* handle;
  CURLM* multi_handle;
  CURLcode result;
  Connection* conn = NULL;

  multi_handle = CURLM_val(v_multi);

  caml_release_runtime_system();
  handle = curlm_remove_finished(multi_handle,&result);
  caml_acquire_runtime_system();

  if (NULL == handle)
  {
    CAMLreturn(Val_none);
  }
  else
  {
    conn = getConnection(handle);
    if (conn->curl_ERRORBUFFER != NULL)
    {
        Store_field(Field(conn->ocamlValues, Ocaml_ERRORBUFFER), 0, caml_copy_string(conn->curl_ERRORBUFFER));
    }
    conn->refcount--;
    /* NB: same handle, but different block */
    v_easy = caml_curl_alloc(conn);
    v_tuple = caml_alloc_tuple(2);
    Store_field(v_tuple,0,v_easy);
    Store_field(v_tuple,1,Val_int(result)); /* CURLcode */
    CAMLreturn(caml_alloc_some(v_tuple));
  }
}
```

the reason is that it makes the incorrect assumption that the refcount should be decremented, without considering that this new handle will be garbage collected and finalisation will be run twice
I also added logging to see this effect in practice:
```
Curl: allocate new handle 0x239cec60 , conn 0x239d01c0
...
Curl: add handle to multi 0x239cec60 , conn 0x239d01c0
...
Curl: allocate new handle 0x239cec60 , conn 0x239d01c0
Curl: removed from mulit, created new handle 0x239cec60 , conn 0x239d01c0
Curl: remove handle 0x239cec60 , conn 0x239d01c0
...
Curl: finalize handle (nil) , conn 0x239d01c0
...
Curl: finalize handle (nil) , conn 0x239d01c0
```

This was a hard won find...

