### PR TITLE
Add support for `ws_meta` and `ws_send`

### DIFF
--- a/config/discover.ml
+++ b/config/discover.ml
@@ -331,6 +331,9 @@ let curl_h_declarations = [
 
   "curl_multi_poll";
   "curl_global_sslset";
+
+  "curl_ws_meta";
+  "curl_ws_send";
 ]
 
 let header_h_declarations = [

--- a/config/discover.ml
+++ b/config/discover.ml
@@ -333,7 +333,6 @@ let curl_h_declarations = [
   "curl_global_sslset";
 
   "curl_ws_meta";
-  "curl_ws_send";
 ]
 
 let header_h_declarations = [

--- a/curl-helper.c
+++ b/curl-helper.c
@@ -5377,6 +5377,115 @@ value caml_curl_check_enums(value v_unit)
   CAMLreturn(v_r);
 }
 
+#if LIBCURL_VERSION_NUM >= 0x075600
+/* WebSocket flags mapping: same order as OCaml variant */
+static const long wsFlags[] = {
+  CURLWS_TEXT,    /* 0 */
+  CURLWS_BINARY,  /* 1 */
+  CURLWS_CONT,    /* 2 */
+  CURLWS_CLOSE,   /* 3 */
+  CURLWS_PING,    /* 4 */
+  CURLWS_PONG,    /* 5 */
+  CURLWS_OFFSET   /* 6 */
+};
+#endif
+
+static value curlWSFlag_list_of_int(int flags)
+{
+  CAMLparam0();
+  CAMLlocal2(result, current);
+
+  result = Val_int(0); // empty list
+
+#if LIBCURL_VERSION_NUM >= 0x075600
+  for (int i = 0; i < (int)(sizeof(wsFlags) / sizeof(wsFlags[0])); i++) {
+    if (flags & wsFlags[i]) {
+      current = caml_alloc_small(2, 0);
+      Field(current, 0) = Val_int(i);
+      Field(current, 1) = result;
+      result = current;
+    }
+  }
+#endif
+
+  CAMLreturn(result);
+}
+
+
+static int curlWSFlag_list_to_int(value flag_list)
+{
+  CAMLparam1(flag_list);
+
+#if LIBCURL_VERSION_NUM >= 0x075600
+  long flags = convert_bit_list(wsFlags, sizeof(wsFlags) / sizeof(wsFlags[0]), flag_list);
+  CAMLreturn((int)flags);
+#else
+  CAMLreturn(0);
+#endif
+}
+
+value caml_curl_ws_meta(value conn_v)
+{
+  CAMLparam1(conn_v);
+  CAMLlocal2(result, frame_record);
+  Connection *conn = Connection_val(conn_v);
+  const struct curl_ws_frame* frame;
+
+  // Check if curl_ws_meta is available (added in libcurl 7.86.0)
+#if LIBCURL_VERSION_NUM >= 0x075600
+  caml_enter_blocking_section();
+  frame = curl_ws_meta(conn->handle);
+  caml_leave_blocking_section();
+
+  if (frame == NULL) {
+    // No WebSocket frame information available
+    CAMLreturn(Val_none);
+  }
+
+  // Create OCaml record: { age; flags; offset; bytesleft }
+  frame_record = caml_alloc(4, 0);
+  Store_field(frame_record, 0, Val_int(frame->age));
+  Store_field(frame_record, 1, curlWSFlag_list_of_int(frame->flags));
+  Store_field(frame_record, 2, caml_copy_int64(frame->offset));
+  Store_field(frame_record, 3, caml_copy_int64(frame->bytesleft));
+
+  // Wrap in Some()
+  result = caml_alloc_small(1, 0);
+  Store_field(result, 0, frame_record);
+
+  CAMLreturn(result);
+#else
+  caml_failwith("WebSocket support not available in this libcurl version");
+#endif
+}
+
+value caml_curl_ws_send(value conn_v, value buffer_v, value flags_v)
+{
+  CAMLparam3(conn_v, buffer_v, flags_v);
+  Connection *conn = Connection_val(conn_v);
+  size_t sent;
+  CURLcode result;
+
+  // Check if curl_ws_send is available (added in libcurl 7.86.0)
+#if LIBCURL_VERSION_NUM >= 0x075600
+  const char* buffer = String_val(buffer_v);
+  size_t buffer_len = caml_string_length(buffer_v);
+  int flags = curlWSFlag_list_to_int(flags_v);
+
+  caml_enter_blocking_section();
+  result = curl_ws_send(conn->handle, buffer, buffer_len, &sent, 0, flags);
+  caml_leave_blocking_section();
+
+  if (result != CURLE_OK) {
+    raiseError(conn, result);
+  }
+
+  CAMLreturn(Val_long(sent));
+#else
+  caml_failwith("WebSocket support not available in this libcurl version");
+#endif
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/curl-helper.c
+++ b/curl-helper.c
@@ -5397,7 +5397,7 @@ static value curlWSFlag_list_of_int(int flags)
 
   for (int i = 0; i < (int)(sizeof(wsFlags) / sizeof(wsFlags[0])); i++) {
     if (flags & wsFlags[i]) {
-      result = Val_cons(Val_int(i), result);
+      result = Val_cons(result, Val_int(i));
     }
   }
 
@@ -5451,7 +5451,7 @@ value caml_curl_ws_send(value conn_v, value buffer_v, value flags_v)
   CURLcode result;
 
 #if HAVE_DECL_CURL_WS_SEND
-  const char* buffer = strdup_ml(buffer_v);
+  char* buffer = strdup_ml(buffer_v);
   size_t buffer_len = caml_string_length(buffer_v);
   int flags = curlWSFlag_list_to_int(flags_v);
 

--- a/curl-helper.c
+++ b/curl-helper.c
@@ -5393,7 +5393,7 @@ static const long wsFlags[] = {
 static value curlWSFlag_list_of_int(int flags)
 {
   CAMLparam0();
-  CAMLlocal2(result, current);
+  CAMLlocal1(result);
 
   result = Val_emptylist;
 
@@ -5424,7 +5424,7 @@ static int curlWSFlag_list_to_int(value flag_list)
 value caml_curl_ws_meta(value conn_v)
 {
   CAMLparam1(conn_v);
-  CAMLlocal2(result, frame_record);
+  CAMLlocal1(frame_record);
   Connection *conn = Connection_val(conn_v);
   const struct curl_ws_frame* frame;
 

--- a/curl-helper.c
+++ b/curl-helper.c
@@ -5377,6 +5377,7 @@ value caml_curl_check_enums(value v_unit)
   CAMLreturn(v_r);
 }
 
+#if HAVE_DECL_CURL_WS_META
 /* WebSocket flags mapping: same order as OCaml variant */
 static const long wsFlags[] = {
   CURLWS_TEXT,    /* 0 */
@@ -5404,13 +5405,12 @@ static value curlWSFlag_list_of_int(int flags)
   CAMLreturn(result);
 }
 
-
 static int curlWSFlag_list_to_int(value flag_list)
 {
   CAMLparam1(flag_list);
   long flags = convert_bit_list(wsFlags, sizeof(wsFlags) / sizeof(wsFlags[0]), flag_list);
 
-  CAMLreturn((int)flags);
+  CAMLreturnT(int, flags);
 }
 
 value caml_curl_ws_meta(value conn_v)
@@ -5420,7 +5420,6 @@ value caml_curl_ws_meta(value conn_v)
   Connection *conn = Connection_val(conn_v);
   const struct curl_ws_frame* frame;
 
-#if HAVE_DECL_CURL_WS_META
   caml_release_runtime_system();
   frame = curl_ws_meta(conn->handle);
   caml_acquire_runtime_system();
@@ -5438,9 +5437,6 @@ value caml_curl_ws_meta(value conn_v)
   Store_field(frame_record, 3, Val_int(frame->bytesleft));
 
   CAMLreturn(caml_alloc_some(frame_record));
-#else
-  caml_failwith("WebSocket support not available in this libcurl version");
-#endif
 }
 
 value caml_curl_ws_send(value conn_v, value buffer_v, value flags_v)
@@ -5450,7 +5446,6 @@ value caml_curl_ws_send(value conn_v, value buffer_v, value flags_v)
   size_t sent;
   CURLcode result;
 
-#if HAVE_DECL_CURL_WS_SEND
   char* buffer = strdup_ml(buffer_v);
   size_t buffer_len = caml_string_length(buffer_v);
   int flags = curlWSFlag_list_to_int(flags_v);
@@ -5466,10 +5461,18 @@ value caml_curl_ws_send(value conn_v, value buffer_v, value flags_v)
   }
 
   CAMLreturn(Val_long(sent));
-#else
-  caml_failwith("WebSocket support not available in this libcurl version");
-#endif
 }
+#else
+value caml_curl_ws_meta(value conn_v)
+{
+  caml_failwith("WebSocket support not available");
+}
+
+value caml_curl_ws_send(value conn_v, value buffer_v, value flags_v)
+{
+  caml_failwith("WebSocket support not available");
+}
+#endif
 
 #ifdef __cplusplus
 }

--- a/curl-helper.c
+++ b/curl-helper.c
@@ -5430,9 +5430,9 @@ value caml_curl_ws_meta(value conn_v)
 
   // Check if curl_ws_meta is available (added in libcurl 7.86.0)
 #if LIBCURL_VERSION_NUM >= 0x075600
-  caml_enter_blocking_section();
+  caml_release_runtime_system();
   frame = curl_ws_meta(conn->handle);
-  caml_leave_blocking_section();
+  caml_acquire_runtime_system();
 
   if (frame == NULL) {
     // No WebSocket frame information available

--- a/curl-helper.c
+++ b/curl-helper.c
@@ -5407,10 +5407,7 @@ static value curlWSFlag_list_of_int(int flags)
 
 static int curlWSFlag_list_to_int(value flag_list)
 {
-  CAMLparam1(flag_list);
-  long flags = convert_bit_list(wsFlags, sizeof(wsFlags) / sizeof(wsFlags[0]), flag_list);
-
-  CAMLreturnT(int, flags);
+  return convert_bit_list(wsFlags, sizeof(wsFlags) / sizeof(wsFlags[0]), flag_list);
 }
 
 value caml_curl_ws_meta(value conn_v)

--- a/curl-helper.c
+++ b/curl-helper.c
@@ -5377,7 +5377,6 @@ value caml_curl_check_enums(value v_unit)
   CAMLreturn(v_r);
 }
 
-#if LIBCURL_VERSION_NUM >= 0x075600
 /* WebSocket flags mapping: same order as OCaml variant */
 static const long wsFlags[] = {
   CURLWS_TEXT,    /* 0 */
@@ -5388,7 +5387,6 @@ static const long wsFlags[] = {
   CURLWS_PONG,    /* 5 */
   CURLWS_OFFSET   /* 6 */
 };
-#endif
 
 static value curlWSFlag_list_of_int(int flags)
 {
@@ -5397,13 +5395,11 @@ static value curlWSFlag_list_of_int(int flags)
 
   result = Val_emptylist;
 
-#if LIBCURL_VERSION_NUM >= 0x075600
   for (int i = 0; i < (int)(sizeof(wsFlags) / sizeof(wsFlags[0])); i++) {
     if (flags & wsFlags[i]) {
       result = Val_cons(Val_int(i), result);
     }
   }
-#endif
 
   CAMLreturn(result);
 }
@@ -5412,13 +5408,9 @@ static value curlWSFlag_list_of_int(int flags)
 static int curlWSFlag_list_to_int(value flag_list)
 {
   CAMLparam1(flag_list);
-
-#if LIBCURL_VERSION_NUM >= 0x075600
   long flags = convert_bit_list(wsFlags, sizeof(wsFlags) / sizeof(wsFlags[0]), flag_list);
+
   CAMLreturn((int)flags);
-#else
-  CAMLreturn(0);
-#endif
 }
 
 value caml_curl_ws_meta(value conn_v)
@@ -5428,8 +5420,7 @@ value caml_curl_ws_meta(value conn_v)
   Connection *conn = Connection_val(conn_v);
   const struct curl_ws_frame* frame;
 
-  // Check if curl_ws_meta is available (added in libcurl 7.86.0)
-#if LIBCURL_VERSION_NUM >= 0x075600
+#if HAVE_DECL_CURL_WS_META
   caml_release_runtime_system();
   frame = curl_ws_meta(conn->handle);
   caml_acquire_runtime_system();
@@ -5459,8 +5450,7 @@ value caml_curl_ws_send(value conn_v, value buffer_v, value flags_v)
   size_t sent;
   CURLcode result;
 
-  // Check if curl_ws_send is available (added in libcurl 7.86.0)
-#if LIBCURL_VERSION_NUM >= 0x075600
+#if HAVE_DECL_CURL_WS_SEND
   const char* buffer = strdup_ml(buffer_v);
   size_t buffer_len = caml_string_length(buffer_v);
   int flags = curlWSFlag_list_to_int(flags_v);

--- a/curl-helper.c
+++ b/curl-helper.c
@@ -5395,15 +5395,12 @@ static value curlWSFlag_list_of_int(int flags)
   CAMLparam0();
   CAMLlocal2(result, current);
 
-  result = Val_int(0); // empty list
+  result = Val_emptylist;
 
 #if LIBCURL_VERSION_NUM >= 0x075600
   for (int i = 0; i < (int)(sizeof(wsFlags) / sizeof(wsFlags[0])); i++) {
     if (flags & wsFlags[i]) {
-      current = caml_alloc_small(2, 0);
-      Field(current, 0) = Val_int(i);
-      Field(current, 1) = result;
-      result = current;
+      result = Val_cons(Val_int(i), result);
     }
   }
 #endif
@@ -5446,14 +5443,10 @@ value caml_curl_ws_meta(value conn_v)
   frame_record = caml_alloc(4, 0);
   Store_field(frame_record, 0, Val_int(frame->age));
   Store_field(frame_record, 1, curlWSFlag_list_of_int(frame->flags));
-  Store_field(frame_record, 2, caml_copy_int64(frame->offset));
-  Store_field(frame_record, 3, caml_copy_int64(frame->bytesleft));
+  Store_field(frame_record, 2, Val_int(frame->offset));
+  Store_field(frame_record, 3, Val_int(frame->bytesleft));
 
-  // Wrap in Some()
-  result = caml_alloc_small(1, 0);
-  Store_field(result, 0, frame_record);
-
-  CAMLreturn(result);
+  CAMLreturn(caml_alloc_some(frame_record));
 #else
   caml_failwith("WebSocket support not available in this libcurl version");
 #endif
@@ -5468,13 +5461,15 @@ value caml_curl_ws_send(value conn_v, value buffer_v, value flags_v)
 
   // Check if curl_ws_send is available (added in libcurl 7.86.0)
 #if LIBCURL_VERSION_NUM >= 0x075600
-  const char* buffer = String_val(buffer_v);
+  const char* buffer = strdup_ml(buffer_v);
   size_t buffer_len = caml_string_length(buffer_v);
   int flags = curlWSFlag_list_to_int(flags_v);
 
-  caml_enter_blocking_section();
+  caml_release_runtime_system();
   result = curl_ws_send(conn->handle, buffer, buffer_len, &sent, 0, flags);
-  caml_leave_blocking_section();
+  caml_acquire_runtime_system();
+
+  free(buffer);
 
   if (result != CURLE_OK) {
     raiseError(conn, result);

--- a/curl-helper.c
+++ b/curl-helper.c
@@ -5443,15 +5443,14 @@ value caml_curl_ws_send(value conn_v, value buffer_v, value flags_v)
   size_t sent;
   CURLcode result;
 
-  char* buffer = strdup_ml(buffer_v);
+  char* buffer = caml_stat_strdup(String_val(buffer_v));
   size_t buffer_len = caml_string_length(buffer_v);
   int flags = curlWSFlag_list_to_int(flags_v);
 
   caml_release_runtime_system();
   result = curl_ws_send(conn->handle, buffer, buffer_len, &sent, 0, flags);
+  caml_stat_free(buffer);
   caml_acquire_runtime_system();
-
-  free(buffer);
 
   if (result != CURLE_OK) {
     raiseError(conn, result);

--- a/curl.ml
+++ b/curl.ml
@@ -654,8 +654,8 @@ type curlWSFlag =
 type curlWSFrame = {
   age: int;
   flags: curlWSFlag list;
-  offset: int64;
-  bytesleft: int64;
+  offset: int;
+  bytesleft: int;
 }
 
 external ws_meta : t -> curlWSFrame option = "caml_curl_ws_meta"

--- a/curl.ml
+++ b/curl.ml
@@ -641,6 +641,26 @@ external get_headers_rev: t -> headerOrigin list -> int -> (string * string) lis
 
 let get_headers t origins ~request = get_headers_rev t origins request |> List.rev
 
+(** WebSocket support *)
+type curlWSFlag =
+  | CURLWS_TEXT
+  | CURLWS_BINARY
+  | CURLWS_CONT
+  | CURLWS_CLOSE
+  | CURLWS_PING
+  | CURLWS_PONG
+  | CURLWS_OFFSET
+
+type curlWSFrame = {
+  age: int;
+  flags: curlWSFlag list;
+  offset: int64;
+  bytesleft: int64;
+}
+
+external ws_meta : t -> curlWSFrame option = "caml_curl_ws_meta"
+external ws_send : t -> string -> curlWSFlag list -> int = "caml_curl_ws_send"
+
 let set_writefunction conn closure =
   setopt conn (CURLOPT_WRITEFUNCTION closure)
 
@@ -1526,6 +1546,8 @@ class handle =
     method get_conditionunmet = get_conditionunmet conn
     method get_certinfo = get_certinfo conn
     method get_http_version = get_http_version conn
+    method ws_meta = ws_meta conn
+    method ws_send = ws_send conn
 end
 
 module Multi = struct

--- a/curl.mli
+++ b/curl.mli
@@ -621,6 +621,26 @@ type headerOrigin =
 *)
 val get_headers : t -> headerOrigin list -> request:int -> (string * string) list
 
+(** {2 WebSocket support} *)
+
+(** WebSocket frame flags *)
+type curlWSFlag =
+  | CURLWS_TEXT    (** The buffer contains text data. Note that this makes a difference to WebSocket but libcurl itself will not make any verification of the content or precautions that you actually receive valid UTF-8 content. *)
+  | CURLWS_BINARY  (** This is binary data. *)
+  | CURLWS_CONT    (** This is not the final fragment of the message, it implies that there is another fragment coming as part of the same message. *)
+  | CURLWS_CLOSE   (** This is a close message. No more data follows. *)
+  | CURLWS_PING    (** This is a ping message. *)
+  | CURLWS_PONG    (** This is a pong message. *)
+  | CURLWS_OFFSET  (** The provided data is only a partial frame and there is more coming in a following call to ws_send. *)
+
+(** WebSocket frame information structure *)
+type curlWSFrame = {
+  age: int;              (** zero *)
+  flags: curlWSFlag list;(** options for the frame *)
+  offset: int64;         (** the offset of this data into the frame *)
+  bytesleft: int64;      (** number of pending bytes left of the payload *)
+}
+
 (** {2 MultiSSL mode } *)
 
 exception CurlSslSetException of curlSslSet
@@ -924,6 +944,12 @@ val get_certinfo : t -> string list list
 val get_http_version : t -> curlHTTPVersion
 (** @since 0.9.2 *)
 
+val ws_meta : t -> curlWSFrame option
+(** Get WebSocket frame information. Returns None if no WebSocket frame info is available. Raises an exception if the operation not supported (libcurl version < 7.86.0). *)
+
+val ws_send : t -> string -> curlWSFlag list -> int
+(** Send WebSocket data. Returns the number of bytes sent. Raises an exception if the operation not supported (libcurl version < 7.86.0).  *)
+
 (** {2 Object interface} *)
 
 class handle :
@@ -1124,6 +1150,8 @@ class handle :
     method get_conditionunmet : bool
     method get_certinfo : string list list
     method get_http_version : curlHTTPVersion
+    method ws_meta : curlWSFrame option
+    method ws_send : string -> curlWSFlag list -> int
   end
 
 (** {2 curl_multi API} *)

--- a/curl.mli
+++ b/curl.mli
@@ -637,8 +637,8 @@ type curlWSFlag =
 type curlWSFrame = {
   age: int;              (** zero *)
   flags: curlWSFlag list;(** options for the frame *)
-  offset: int64;         (** the offset of this data into the frame *)
-  bytesleft: int64;      (** number of pending bytes left of the payload *)
+  offset: int;           (** the offset of this data into the frame *)
+  bytesleft: int;        (** number of pending bytes left of the payload *)
 }
 
 (** {2 MultiSSL mode } *)

--- a/examples/dune
+++ b/examples/dune
@@ -18,21 +18,25 @@
 (executables
  (names
   opar
-  ocurl_test_threads)
+  ocurl_test_threads
+  test_ws)
  (libraries curl threads)
  (modules
   opar
-  ocurl_test_threads))
+  ocurl_test_threads
+  test_ws))
 
 (executables
  (names
   test_lwt
-  test_lwt_unit)
+  test_lwt_unit
+  test_lwt_ws)
  (libraries curl.lwt)
  (preprocess (pps lwt_ppx))
  (modules
   test_lwt
-  test_lwt_unit))
+  test_lwt_unit
+  test_lwt_ws))
 
 (rule
  (alias runtest)

--- a/examples/test_lwt_ws.ml
+++ b/examples/test_lwt_ws.ml
@@ -1,0 +1,71 @@
+open Curl
+
+let write_callback conn data =
+  begin
+    match ws_meta conn with
+    | Some frame ->
+      if List.mem CURLWS_TEXT frame.flags then (
+        Printf.printf "Received TEXT: %s\n%!" data;
+      ) else (
+        Printf.printf "Received non-TEXT frame: ";
+        List.iter (function
+          | CURLWS_TEXT -> Printf.printf "TEXT;"
+          | CURLWS_BINARY -> Printf.printf "BINARY;"
+          | CURLWS_CONT -> Printf.printf "CONT;"
+          | CURLWS_CLOSE -> Printf.printf "CLOSE;"
+          | CURLWS_PING -> Printf.printf "PING;"
+          | CURLWS_PONG -> Printf.printf "PONG;"
+          | CURLWS_OFFSET -> Printf.printf "OFFSET;"
+        ) frame.flags;
+        Printf.printf "\n%!";
+      )
+    | None ->
+      Printf.printf "Received data without frame info: %s\n%!" data
+    end;
+  String.length data
+
+let () =
+  let conn = init () in
+  let send_message () =
+    Lwt_unix.sleep 5.0;%lwt
+    let test_message = "Hello websocket from OCaml" in
+    (try
+      let bytes_sent = ws_send conn test_message [CURLWS_TEXT] in
+      Lwt_io.printf "Sent %d bytes: '%s'\n%!" bytes_sent test_message
+    with
+    | e -> Lwt_io.eprintf "Send error: %s\n%!" (Printexc.to_string e))
+  in
+  let send_ping () =
+    Lwt_unix.sleep 5.0;%lwt
+    (try
+      let bytes_sent = ws_send conn "ping" [CURLWS_PING] in
+      Lwt_io.printf "Sent %d bytes: ping\n%!" bytes_sent
+    with
+    | e -> Lwt_io.eprintf "Send error: %s\n%!" (Printexc.to_string e))
+  in
+  Lwt_main.run begin
+  (try
+    setopt conn (CURLOPT_URL "wss://echo.websocket.org/");
+    setopt conn (CURLOPT_WRITEFUNCTION (write_callback conn));
+    setopt conn (CURLOPT_VERBOSE false);
+    Lwt_io.printf "Starting WebSocket connection...\n%!";%lwt
+    let perform () =
+      let%lwt code = Curl_lwt.perform conn in
+      Lwt_io.printf "WebSocket echo test completed with code: %d\n%!" (Curl.int_of_curlCode code)
+    in
+    let wait_and_stop () =
+      Lwt_unix.sleep 10.0;%lwt
+      Lwt_io.printf "Stopping WebSocket connection...\n%!"
+    in
+    Lwt.choose [
+      wait_and_stop ();
+      Lwt.join [perform (); send_message (); send_ping ()]
+    ]
+  with
+  | CurlException (code, _, msg) ->
+    Lwt_io.eprintf "Curl error %s: %s\n%!" (strerror code) msg
+  | e ->
+    Lwt_io.eprintf "Other error: %s\n%!" (Printexc.to_string e));%lwt
+  cleanup conn;
+  Lwt.return_unit
+  end

--- a/examples/test_ws.ml
+++ b/examples/test_ws.ml
@@ -1,0 +1,78 @@
+open Curl
+
+let received_data = ref ""
+let received_mutex = Mutex.create ()
+let received_intro = ref false
+
+let write_callback conn data =
+  Mutex.lock received_mutex;
+  if not !received_intro then (
+    received_intro := true;
+    Printf.printf "Received intro: %s\n%!" data;
+  ) else begin
+    match ws_meta conn with
+    | Some frame ->
+      if List.mem CURLWS_TEXT frame.flags then (
+        received_data := !received_data ^ data;
+        Printf.printf "Received TEXT: %s\n%!" data;
+      ) else (
+        Printf.printf "Received non-TEXT frame: ";
+        List.iter (function
+          | CURLWS_TEXT -> Printf.printf "TEXT;"
+          | CURLWS_BINARY -> Printf.printf "BINARY;"
+          | CURLWS_CONT -> Printf.printf "CONT;"
+          | CURLWS_CLOSE -> Printf.printf "CLOSE;"
+          | CURLWS_PING -> Printf.printf "PING;"
+          | CURLWS_PONG -> Printf.printf "PONG;"
+          | CURLWS_OFFSET -> Printf.printf "OFFSET;"
+        ) frame.flags;
+        Printf.printf "\n%!";
+      )
+    | None ->
+      Printf.printf "Received data without frame info: %s\n%!" data;
+      received_data := !received_data ^ data
+   end;
+  Mutex.unlock received_mutex;
+  String.length data
+
+let () =
+  global_init CURLINIT_GLOBALALL;
+  let conn = init () in
+  (try
+    setopt conn (CURLOPT_URL "wss://echo.websocket.org/");
+    setopt conn (CURLOPT_WRITEFUNCTION (write_callback conn));
+    setopt conn (CURLOPT_VERBOSE false);
+    Printf.printf "Starting WebSocket connection...\n%!";
+    let _ = Thread.create (fun () ->
+      try
+        perform conn
+      with
+      | e -> Printf.eprintf "Connection error: %s\n%!" (Printexc.to_string e)
+    ) () in
+    Unix.sleep 5;
+    let test_message = "Hello websocket from OCaml" in
+    (try
+      let bytes_sent = ws_send conn test_message [CURLWS_TEXT] in
+      Printf.printf "Sent %d bytes: '%s'\n%!" bytes_sent test_message;
+    with
+    | e -> Printf.eprintf "Send error: %s\n%!" (Printexc.to_string e));
+    Unix.sleep 5;
+    Mutex.lock received_mutex;
+    Printf.printf "Final received data: '%s'\n%!" !received_data;
+    received_data := "";
+    Mutex.unlock received_mutex;
+    Unix.sleep 5;
+    (try
+      let bytes_sent = ws_send conn "ping" [CURLWS_PING] in
+      Printf.printf "Sent %d bytes: ping\n%!" bytes_sent;
+    with
+    | e -> Printf.eprintf "Send error: %s\n%!" (Printexc.to_string e));
+    Unix.sleep 5;
+    Printf.printf "WebSocket echo test completed!\n%!";
+  with
+  | CurlException (code, _, msg) ->
+    Printf.eprintf "Curl error %s: %s\n%!" (strerror code) msg
+  | e ->
+    Printf.eprintf "Other error: %s\n%!" (Printexc.to_string e));
+  cleanup conn;
+  global_cleanup ()


### PR DESCRIPTION
As described in [libcurl's docs. on websocket](https://curl.se/docs/websocket.html), there's a way of using websockets via the write callback:
> Get the WebSocket frames from the server sent to the write callback. You can then respond with curl_ws_send() from within the callback (or outside of it).

This means that we can handle websocket connections by just adding `curl_ws_send` and `curl_ws_meta`:
```
$ dune exec -- examples/test_lwt_ws.exe
Starting WebSocket connection...   
Received TEXT: Request served by d56832234ce08e
Sent 4 bytes: ping
Sent 26 bytes: 'Hello websocket from OCaml'
Received non-TEXT frame: PONG;
Received TEXT: Hello websocket from OCaml
Stopping WebSocket connection...
$ dune exec -- examples/test_ws.exe
Starting WebSocket connection...    
Received intro: Request served by e286e427f61668
Sent 26 bytes: 'Hello websocket from OCaml'
Received TEXT: Hello websocket from OCaml
Final received data: 'Hello websocket from OCaml'
Sent 4 bytes: ping
Received non-TEXT frame: PONG;
WebSocket echo test completed!
```

This wouldn't completely close #75 , as it is not implementing `ws_recv`.