### PR TITLE
Derive sexp_of

### DIFF
--- a/curl.ml
+++ b/curl.ml
@@ -5,7 +5,7 @@
  * Copyright (c) 2009, ygrek, <ygrek@autistici.org>
  *)
 
-open Sexplib0.Sexp_conv
+open! Sexplib0.Sexp_conv
 type t
 
 type curlCode =

--- a/curl.ml
+++ b/curl.ml
@@ -5,6 +5,7 @@
  * Copyright (c) 2009, ygrek, <ygrek@autistici.org>
  *)
 
+open Sexplib.Conv
 type t
 
 type curlCode =
@@ -90,6 +91,7 @@ type curlCode =
   | CURLE_SSH
   | CURLE_SSL_SHUTDOWN_FAILED
   | CURLE_AGAIN
+[@@deriving sexp_of]
 
 exception CurlException of (curlCode * int * string)
 
@@ -181,6 +183,7 @@ type curlDebugType =
   | DEBUGTYPE_SSL_DATA_IN
   | DEBUGTYPE_SSL_DATA_OUT
   | DEBUGTYPE_END
+[@@deriving sexp_of]
 
 type curlAuth =
   | CURLAUTH_BASIC
@@ -622,6 +625,7 @@ type version_info = {
   iconv_ver_num : int;
   libssh_version : string;
 }
+[@@deriving sexp_of]
 
 external version_info : unit -> version_info = "caml_curl_version_info"
 
@@ -1606,9 +1610,11 @@ module Multi = struct
 
   (* see curlm_sock_cb *)
   type poll = POLL_NONE | POLL_IN | POLL_OUT | POLL_INOUT | POLL_REMOVE
+[@@deriving sexp_of]
 
   (* see caml_curl_multi_socket_action *)
   type fd_status = EV_AUTO | EV_IN | EV_OUT | EV_INOUT
+[@@deriving sexp_of]
 
   external set_socket_function : mt -> (Unix.file_descr -> poll -> unit) -> unit = "caml_curl_multi_socketfunction"
   external set_timer_function : mt -> (int -> unit) -> unit = "caml_curl_multi_timerfunction"

--- a/curl.ml
+++ b/curl.ml
@@ -5,7 +5,7 @@
  * Copyright (c) 2009, ygrek, <ygrek@autistici.org>
  *)
 
-open Sexplib.Conv
+open Sexplib0.Sexp_conv
 type t
 
 type curlCode =

--- a/curl.mli
+++ b/curl.mli
@@ -94,6 +94,7 @@ type curlCode =
   | CURLE_SSH
   | CURLE_SSL_SHUTDOWN_FAILED
   | CURLE_AGAIN
+[@@deriving sexp_of]
 
 exception CurlException of (curlCode * int * string)
 
@@ -189,6 +190,7 @@ type curlDebugType =
   | DEBUGTYPE_SSL_DATA_IN
   | DEBUGTYPE_SSL_DATA_OUT
   | DEBUGTYPE_END
+[@@deriving sexp_of]
 
 type curlAuth =
   | CURLAUTH_BASIC
@@ -607,6 +609,7 @@ type version_info = {
   iconv_ver_num : int;
   libssh_version : string;
 }
+[@@deriving sexp_of]
 
 type pauseOption = PAUSE_SEND | PAUSE_RECV | PAUSE_ALL
 
@@ -1233,6 +1236,7 @@ module Multi : sig
     | POLL_OUT     (** available for writing *)
     | POLL_INOUT   (** both *)
     | POLL_REMOVE  (** socket not needed anymore *)
+[@@deriving sexp_of]
 
   (** socket status *)
   type fd_status =
@@ -1240,6 +1244,7 @@ module Multi : sig
     | EV_IN    (** socket has incoming data *)
     | EV_OUT   (** socket is available for writing *)
     | EV_INOUT (** both *)
+[@@deriving sexp_of]
 
   (** set the function to receive notifications on what socket events
       are currently interesting for libcurl on the specified socket handle *)

--- a/curl.opam
+++ b/curl.opam
@@ -17,6 +17,7 @@ depends: [
   "base-bigarray"
   "base-unix"
   "conf-libcurl"
+  "sexplib0"
   "odoc" {with-doc}
 ]
 conflicts: [

--- a/curl.opam
+++ b/curl.opam
@@ -18,6 +18,7 @@ depends: [
   "base-unix"
   "conf-libcurl"
   "sexplib0"
+  "ppx_sexp_conv"
   "odoc" {with-doc}
 ]
 conflicts: [

--- a/dune
+++ b/dune
@@ -8,7 +8,7 @@
   (flags -DHAVE_CONFIG_H :standard (:include cflags.sexp))
   (names curl-helper))
  (c_library_flags :standard (:include clibs.sexp))
- (libraries bigarray unix)
+ (libraries bigarray unix sexplib0)
  (modules curl))
 
 (library

--- a/dune
+++ b/dune
@@ -9,7 +9,8 @@
   (names curl-helper))
  (c_library_flags :standard (:include clibs.sexp))
  (libraries bigarray unix sexplib0)
- (modules curl))
+ (modules curl)
+ (preprocess (pps ppx_sexp_conv)))
 
 (library
  (name curl_lwt)

--- a/dune-project
+++ b/dune-project
@@ -26,7 +26,8 @@
   (dune-configurator (>= "3.18.1"))
   base-bigarray
   base-unix  
-  conf-libcurl)
+  conf-libcurl
+  sexplib0)
  (conflicts
   (ocurl (<> "transition")))
  (tags (org:ygrek clib:curl)))

--- a/dune-project
+++ b/dune-project
@@ -27,7 +27,8 @@
   base-bigarray
   base-unix  
   conf-libcurl
-  sexplib0)
+  sexplib0
+  ppx_sexp_conv)
  (conflicts
   (ocurl (<> "transition")))
  (tags (org:ygrek clib:curl)))


### PR DESCRIPTION
Using `[@@deriving sexp_of]` on exposed types is helpful for formatting good errors and other messages that can contain curl types. 

I realize that this is possibly controversial because it's just one opinion on how to format such things (other people may prefer string over sexp, etc). 

My direct application here is that I'd like to open source an curl client that works with Async. Having these derivations in the source means I don't need a bunch of boilerplate inside that client to do formatting. I can probably come up with something else if this isn't acceptable.