### PR TITLE
Use CURLOPT_OPENSOCKETFUNCTION without creating socket

### DIFF
--- a/curl-helper.c
+++ b/curl-helper.c
@@ -1323,8 +1323,10 @@ static curl_socket_t cb_OPENSOCKETFUNCTION2(void *data,
     }
 
     union sock_addr_union sock_addr;
-    memcpy(&sock_addr, &(addr->addr), addr->addrlen < sizeof(sock_addr) ? addr->addrlen : sizeof(sock_addr));
-    value v_unix_sockaddr = alloc_sockaddr(&sock_addr, addr->addrlen, -1);
+    socklen_t addrlen = addr->addrlen;
+    if (addrlen > sizeof(sock_addr)) addrlen = sizeof(sock_addr);
+    memcpy(&sock_addr.s_gen, &(addr->addr), addrlen);
+    value v_unix_sockaddr = alloc_sockaddr(&sock_addr, addrlen, -1);
 
     v_sockaddr_record = caml_alloc(4, 0);
     Store_field(v_sockaddr_record, 0, v_sockdomain);

--- a/curl-helper.c
+++ b/curl-helper.c
@@ -32,6 +32,7 @@
 #include <caml/callback.h>
 #include <caml/fail.h>
 #include <caml/unixsupport.h>
+#include <caml/socketaddr.h>
 #include <caml/custom.h>
 #include <caml/threads.h>
 #include <caml/bigarray.h>
@@ -1271,6 +1272,80 @@ static int cb_OPENSOCKETFUNCTION(void *data,
     return ((sock == -1) ? CURL_SOCKET_BAD : sock);
 }
 
+static int cb_OPENSOCKETFUNCTION2(void *data,
+                        curlsocktype purpose,
+                        struct curl_sockaddr *addr)
+{
+    caml_acquire_runtime_system();
+
+    CAMLparam0();
+    CAMLlocal5(result, v_sock_purpose, v_sockdomain, v_socktype, v_sockaddr_record);
+    Connection *conn = (Connection *)data;
+    int sock = -1;
+
+    switch (purpose) {
+        case CURLSOCKTYPE_IPCXN:
+            v_sock_purpose = Val_int(0);
+            break;
+        default:
+            caml_failwith("Invalid socket purpose");
+    }
+
+    switch (addr->family) {
+        case AF_UNIX:
+            v_sockdomain = Val_int(0); /* PF_UNIX */
+            break;
+        case AF_INET:
+            v_sockdomain = Val_int(1); /* PF_INET */
+            break;
+        case AF_INET6:
+            v_sockdomain = Val_int(2); /* PF_INET6 */
+            break;
+        default:
+            caml_failwith("Invalid socket domain");
+    }
+
+    switch (addr->socktype) {
+        case SOCK_STREAM:
+            v_socktype = Val_int(0); /* SOCK_STREAM */
+            break;
+        case SOCK_DGRAM:
+            v_socktype = Val_int(1); /* SOCK_DGRAM */
+            break;
+        case SOCK_RAW:
+            v_socktype = Val_int(2); /* SOCK_RAW */
+            break;
+        case SOCK_SEQPACKET:
+            v_socktype = Val_int(3); /* SOCK_SEQPACKET */
+            break;
+        default:
+            caml_failwith("Invalid socket type");
+    }
+
+    union sock_addr_union sock_addr;
+    memcpy(&sock_addr, &(addr->addr), addr->addrlen < sizeof(sock_addr) ? addr->addrlen : sizeof(sock_addr));
+    value v_unix_sockaddr = alloc_sockaddr(&sock_addr, addr->addrlen, -1);
+
+    v_sockaddr_record = caml_alloc(4, 0);
+    Store_field(v_sockaddr_record, 0, v_sockdomain);
+    Store_field(v_sockaddr_record, 1, v_socktype);
+    Store_field(v_sockaddr_record, 2, Val_int(addr->protocol));
+    Store_field(v_sockaddr_record, 3, v_unix_sockaddr);
+
+    result = caml_callback2_exn(Field(conn->ocamlValues, Ocaml_OPENSOCKETFUNCTION),
+                                v_sock_purpose, v_sockaddr_record);
+
+    if (!Is_exception_result(result))
+    {
+        sock = Socket_val(result);
+    }
+
+    CAMLdrop;
+
+    caml_release_runtime_system();
+    return ((sock == -1) ? CURL_SOCKET_BAD : sock);
+}
+
 static int cb_SSH_KEYFUNCTION(CURL *easy,
                               const struct curl_khkey *knownkey,
                               const struct curl_khkey *foundkey,
@@ -1650,6 +1725,7 @@ SETOPT_FUNCTION( IOCTL)
 #endif
 
 SETOPT_FUNCTION( OPENSOCKET)
+SETOPT_FUNCTION2( OPENSOCKET)
 
 static void handle_slist(Connection *conn, struct curl_slist** slist, CURLoption curl_option, value option)
 {
@@ -3718,6 +3794,7 @@ CURLOptionMapping implementedOptionMap[] =
   HAVENOT(AUTOREFERER),
 #endif
   HAVE(OPENSOCKETFUNCTION),
+  HAVE(OPENSOCKETFUNCTION2),
 #if HAVE_DECL_CURLOPT_PROXYTYPE
   HAVE(PROXYTYPE),
 #else

--- a/curl-helper.c
+++ b/curl-helper.c
@@ -1242,7 +1242,7 @@ static int cb_SEEKFUNCTION(void *data,
 }
 #endif
 
-static int cb_OPENSOCKETFUNCTION(void *data,
+static curl_socket_t cb_OPENSOCKETFUNCTION(void *data,
                         curlsocktype purpose,
                         struct curl_sockaddr *addr)
 {
@@ -1251,28 +1251,28 @@ static int cb_OPENSOCKETFUNCTION(void *data,
     CAMLparam0();
     CAMLlocal1(result);
     Connection *conn = (Connection *)data;
-    int sock = -1;
+    curl_socket_t sock = CURL_SOCKET_BAD;
     (void)purpose; /* not used */
 
     sock = socket(addr->family, addr->socktype, addr->protocol);
 
-    if (-1 != sock)
+    if (CURL_SOCKET_BAD != sock)
     {
       /* FIXME windows */
       result = caml_callback_exn(Field(conn->ocamlValues, Ocaml_OPENSOCKETFUNCTION), Val_int(sock));
       if (Is_exception_result(result))
       {
         close(sock);
-        sock = -1;
+        sock = CURL_SOCKET_BAD;
       }
     }
     CAMLdrop;
 
     caml_release_runtime_system();
-    return ((sock == -1) ? CURL_SOCKET_BAD : sock);
+    return sock;
 }
 
-static int cb_OPENSOCKETFUNCTION2(void *data,
+static curl_socket_t cb_OPENSOCKETFUNCTION2(void *data,
                         curlsocktype purpose,
                         struct curl_sockaddr *addr)
 {
@@ -1281,7 +1281,7 @@ static int cb_OPENSOCKETFUNCTION2(void *data,
     CAMLparam0();
     CAMLlocal5(result, v_sock_purpose, v_sockdomain, v_socktype, v_sockaddr_record);
     Connection *conn = (Connection *)data;
-    int sock = -1;
+    curl_socket_t sock = CURL_SOCKET_BAD;
 
     switch (purpose) {
         case CURLSOCKTYPE_IPCXN:
@@ -1335,18 +1335,15 @@ static int cb_OPENSOCKETFUNCTION2(void *data,
     result = caml_callback2_exn(Field(conn->ocamlValues, Ocaml_OPENSOCKETFUNCTION),
                                 v_sock_purpose, v_sockaddr_record);
 
-    if (!Is_exception_result(result))
+    if (!Is_exception_result(result) && Is_some(result))
     {
-        if (Is_some(result))
-        {
-            sock = Socket_val(Some_val(result));
-        }
+        sock = Socket_val(Some_val(result));
     }
 
     CAMLdrop;
 
     caml_release_runtime_system();
-    return ((sock == -1) ? CURL_SOCKET_BAD : sock);
+    return sock;
 }
 
 static int cb_SSH_KEYFUNCTION(CURL *easy,

--- a/curl-helper.c
+++ b/curl-helper.c
@@ -1288,7 +1288,7 @@ static curl_socket_t cb_OPENSOCKETFUNCTION2(void *data,
             v_sock_purpose = Val_int(0);
             break;
         default:
-            return CURL_SOCKET_BAD;
+            goto cleanup;
     }
 
     switch (addr->family) {
@@ -1302,7 +1302,7 @@ static curl_socket_t cb_OPENSOCKETFUNCTION2(void *data,
             v_sockdomain = Val_int(2); /* PF_INET6 */
             break;
         default:
-            return CURL_SOCKET_BAD;
+            goto cleanup;
     }
 
     switch (addr->socktype) {
@@ -1319,7 +1319,7 @@ static curl_socket_t cb_OPENSOCKETFUNCTION2(void *data,
             v_socktype = Val_int(3); /* SOCK_SEQPACKET */
             break;
         default:
-            return CURL_SOCKET_BAD;
+            goto cleanup;
     }
 
     union sock_addr_union sock_addr;
@@ -1340,6 +1340,7 @@ static curl_socket_t cb_OPENSOCKETFUNCTION2(void *data,
         sock = Socket_val(Some_val(result));
     }
 
+cleanup:
     CAMLdrop;
 
     caml_release_runtime_system();

--- a/curl-helper.c
+++ b/curl-helper.c
@@ -1288,7 +1288,7 @@ static int cb_OPENSOCKETFUNCTION2(void *data,
             v_sock_purpose = Val_int(0);
             break;
         default:
-            caml_failwith("Invalid socket purpose");
+            return CURL_SOCKET_BAD;
     }
 
     switch (addr->family) {
@@ -1302,7 +1302,7 @@ static int cb_OPENSOCKETFUNCTION2(void *data,
             v_sockdomain = Val_int(2); /* PF_INET6 */
             break;
         default:
-            caml_failwith("Invalid socket domain");
+            return CURL_SOCKET_BAD;
     }
 
     switch (addr->socktype) {
@@ -1319,7 +1319,7 @@ static int cb_OPENSOCKETFUNCTION2(void *data,
             v_socktype = Val_int(3); /* SOCK_SEQPACKET */
             break;
         default:
-            caml_failwith("Invalid socket type");
+            return CURL_SOCKET_BAD;
     }
 
     union sock_addr_union sock_addr;

--- a/curl-helper.c
+++ b/curl-helper.c
@@ -1323,10 +1323,12 @@ static curl_socket_t cb_OPENSOCKETFUNCTION2(void *data,
     }
 
     union sock_addr_union sock_addr;
-    socklen_t addrlen = addr->addrlen;
-    if (addrlen > sizeof(sock_addr)) addrlen = sizeof(sock_addr);
-    memcpy(&sock_addr.s_gen, &(addr->addr), addrlen);
-    value v_unix_sockaddr = alloc_sockaddr(&sock_addr, addrlen, -1);
+    if (addr->addrlen > sizeof(sock_addr))
+    {
+        goto cleanup;
+    }
+    memcpy(&sock_addr.s_gen, &(addr->addr), addr->addrlen);
+    value v_unix_sockaddr = alloc_sockaddr(&sock_addr, addr->addrlen, -1);
 
     v_sockaddr_record = caml_alloc(4, 0);
     Store_field(v_sockaddr_record, 0, v_sockdomain);

--- a/curl-helper.c
+++ b/curl-helper.c
@@ -1337,7 +1337,10 @@ static int cb_OPENSOCKETFUNCTION2(void *data,
 
     if (!Is_exception_result(result))
     {
-        sock = Socket_val(result);
+        if (Is_some(result))
+        {
+            sock = Socket_val(Some_val(result));
+        }
     }
 
     CAMLdrop;

--- a/curl.ml
+++ b/curl.ml
@@ -483,7 +483,7 @@ type curlOption =
   | CURLOPT_SEEKFUNCTION of (int64 -> curlSeek -> curlSeekResult)
   | CURLOPT_AUTOREFERER of bool
   | CURLOPT_OPENSOCKETFUNCTION of (Unix.file_descr -> unit)
-  | CURLOPT_OPENSOCKETFUNCTION2 of (curlSockType -> curlSockAddr -> Unix.file_descr)
+  | CURLOPT_OPENSOCKETFUNCTION2 of (curlSockType -> curlSockAddr -> Unix.file_descr option)
 (*   | CURLOPT_CLOSESOCKETFUNCTION of (Unix.file_descr -> unit) *)
   | CURLOPT_PROXYTYPE of curlProxyType
   | CURLOPT_PROTOCOLS of curlProto list

--- a/curl.ml
+++ b/curl.ml
@@ -251,6 +251,16 @@ type curlProxyType =
   | CURLPROXY_SOCKS4A (** added in 7.18.0 *)
   | CURLPROXY_SOCKS5_HOSTNAME (** added in 7.18.0 *)
 
+type curlSockType =
+  | CURLSOCKTYPE_IPCXN
+
+type curlSockAddr = {
+  family: Unix.socket_domain;
+  socktype: Unix.socket_type;
+  protocol: int;
+  address: Unix.sockaddr;
+}
+
 type data_source =
   | String of string (** Equivalent to `CURLMIME_DATA` *)
   | File of string  (** Equivalent to `CURLMIME_FILEDATA` *)
@@ -473,6 +483,7 @@ type curlOption =
   | CURLOPT_SEEKFUNCTION of (int64 -> curlSeek -> curlSeekResult)
   | CURLOPT_AUTOREFERER of bool
   | CURLOPT_OPENSOCKETFUNCTION of (Unix.file_descr -> unit)
+  | CURLOPT_OPENSOCKETFUNCTION2 of (curlSockType -> curlSockAddr -> Unix.file_descr)
 (*   | CURLOPT_CLOSESOCKETFUNCTION of (Unix.file_descr -> unit) *)
   | CURLOPT_PROXYTYPE of curlProxyType
   | CURLOPT_PROTOCOLS of curlProto list
@@ -1076,6 +1087,9 @@ let set_autoreferer conn b =
 let set_opensocketfunction conn closure =
   setopt conn (CURLOPT_OPENSOCKETFUNCTION closure)
 
+let set_opensocketfunction2 conn closure =
+  setopt conn (CURLOPT_OPENSOCKETFUNCTION2 closure)
+
 (*
 let set_closesocketfunction conn closure =
   setopt conn (CURLOPT_CLOSESOCKETFUNCTION closure)
@@ -1496,6 +1510,7 @@ class handle =
     method set_dns_servers l = set_dns_servers conn l
     method set_autoreferer b = set_autoreferer conn b
     method set_opensocketfunction closure = set_opensocketfunction conn closure
+    method set_opensocketfunction2 closure = set_opensocketfunction2 conn closure
 (*     method set_closesocketfunction closure = set_closesocketfunction conn closure *)
     method set_proxytype t = set_proxytype conn t
     method set_mimepost p = set_mimepost conn p

--- a/curl.mli
+++ b/curl.mli
@@ -493,7 +493,7 @@ type curlOption =
   | CURLOPT_SEEKFUNCTION of (int64 -> curlSeek -> curlSeekResult)
   | CURLOPT_AUTOREFERER of bool
   | CURLOPT_OPENSOCKETFUNCTION of (Unix.file_descr -> unit)
-  | CURLOPT_OPENSOCKETFUNCTION2 of (curlSockType -> curlSockAddr -> Unix.file_descr)
+  | CURLOPT_OPENSOCKETFUNCTION2 of (curlSockType -> curlSockAddr -> Unix.file_descr option)
   | CURLOPT_PROXYTYPE of curlProxyType
   | CURLOPT_PROTOCOLS of curlProto list
   | CURLOPT_REDIR_PROTOCOLS of curlProto list
@@ -865,7 +865,7 @@ val set_proxytransfermode : t -> bool -> unit
 val set_seekfunction : t -> (int64 -> curlSeek -> curlSeekResult) -> unit
 val set_autoreferer : t -> bool -> unit
 val set_opensocketfunction : t -> (Unix.file_descr -> unit) -> unit
-val set_opensocketfunction2 : t -> (curlSockType -> curlSockAddr -> Unix.file_descr) -> unit
+val set_opensocketfunction2 : t -> (curlSockType -> curlSockAddr -> Unix.file_descr option) -> unit
 val set_tcpkeepalive : t -> bool -> unit
 val set_tcpkeepidle : t -> int -> unit
 val set_tcpkeepintvl : t -> int -> unit
@@ -1111,7 +1111,7 @@ class handle :
     method set_seekfunction : (int64 -> curlSeek -> curlSeekResult) -> unit
     method set_autoreferer : bool -> unit
     method set_opensocketfunction : (Unix.file_descr -> unit) -> unit
-    method set_opensocketfunction2 : (curlSockType -> curlSockAddr -> Unix.file_descr) -> unit
+    method set_opensocketfunction2 : (curlSockType -> curlSockAddr -> Unix.file_descr option) -> unit
     method set_proxytype : curlProxyType -> unit
     method set_resolve : (string * int * string) list -> (string * int) list -> unit
     method set_dns_servers : string list -> unit

--- a/curl.mli
+++ b/curl.mli
@@ -259,6 +259,16 @@ type curlProxyType =
   | CURLPROXY_SOCKS4A (** since libcurl 7.18.0 *)
   | CURLPROXY_SOCKS5_HOSTNAME (** since libcurl 7.18.0 *)
 
+type curlSockType =
+  | CURLSOCKTYPE_IPCXN
+
+type curlSockAddr = {
+  family: Unix.socket_domain;
+  socktype: Unix.socket_type;
+  protocol: int;
+  address: Unix.sockaddr;
+}
+
 type data_source =
   | String of string (** Equivalent to `CURLMIME_DATA` *)
   | File of string  (** Equivalent to `CURLMIME_FILEDATA` *)
@@ -483,6 +493,7 @@ type curlOption =
   | CURLOPT_SEEKFUNCTION of (int64 -> curlSeek -> curlSeekResult)
   | CURLOPT_AUTOREFERER of bool
   | CURLOPT_OPENSOCKETFUNCTION of (Unix.file_descr -> unit)
+  | CURLOPT_OPENSOCKETFUNCTION2 of (curlSockType -> curlSockAddr -> Unix.file_descr)
   | CURLOPT_PROXYTYPE of curlProxyType
   | CURLOPT_PROTOCOLS of curlProto list
   | CURLOPT_REDIR_PROTOCOLS of curlProto list
@@ -854,6 +865,7 @@ val set_proxytransfermode : t -> bool -> unit
 val set_seekfunction : t -> (int64 -> curlSeek -> curlSeekResult) -> unit
 val set_autoreferer : t -> bool -> unit
 val set_opensocketfunction : t -> (Unix.file_descr -> unit) -> unit
+val set_opensocketfunction2 : t -> (curlSockType -> curlSockAddr -> Unix.file_descr) -> unit
 val set_tcpkeepalive : t -> bool -> unit
 val set_tcpkeepidle : t -> int -> unit
 val set_tcpkeepintvl : t -> int -> unit
@@ -1099,6 +1111,7 @@ class handle :
     method set_seekfunction : (int64 -> curlSeek -> curlSeekResult) -> unit
     method set_autoreferer : bool -> unit
     method set_opensocketfunction : (Unix.file_descr -> unit) -> unit
+    method set_opensocketfunction2 : (curlSockType -> curlSockAddr -> Unix.file_descr) -> unit
     method set_proxytype : curlProxyType -> unit
     method set_resolve : (string * int * string) list -> (string * int) list -> unit
     method set_dns_servers : string list -> unit


### PR DESCRIPTION
The callback [CURLOPT_OPENSOCKETFUNCTION](https://curl.se/libcurl/c/CURLOPT_OPENSOCKETFUNCTION.html) allows to manage a sockaddr before the actual socket is created.

The existing entrypoint to this callback, `set_opensocketfunction`, creates a socket and then passes the socket descriptor to the ocaml callback. So it behaves more like [CURLOPT_SOCKOPTFUNCTION](https://curl.se/libcurl/c/CURLOPT_SOCKOPTFUNCTION.html).

Here's an alternative `set_opensocketfunction2` that passes the sockaddr to a callback that is expected to create and return a socket. This behavior is more aligned with the documented behavior. It enables use cases like [this IP filtering example](https://curl.se/libcurl/c/block_ip.html).

I've made the callback return an optional fd, where `None` entails CURL_SOCKET_BAD. But non-optional return type where CURL_SOCKET_BAD is induced by exception is also ok, no strong preference.