### PR TITLE
Fix deadlock

### DIFF
--- a/curl-helper.c
+++ b/curl-helper.c
@@ -4663,7 +4663,9 @@ value caml_curl_multi_cleanup(value handle)
 
   caml_remove_generational_global_root(&h->values);
 
+  caml_enter_blocking_section();
   CURLcode rc = curl_multi_cleanup(h->handle);
+  caml_leave_blocking_section();
 
   caml_stat_free(h);
   Multi_val(handle) = (ml_multi_handle*)NULL;


### PR DESCRIPTION
`curl_multi_cleanup` may callback to the socket function if there are still connections cached. The callback handler ` will try to acquire the runtime lock. Since the runtime lock was not released in cannot be acquired → deadlock.