### PR TITLE
return number of active handles from timeout

### DIFF
--- a/curl.ml
+++ b/curl.ml
@@ -1631,7 +1631,8 @@ module Multi = struct
   external action_all : mt -> int = "caml_curl_multi_socket_all"
   external socket_action : mt -> Unix.file_descr option -> fd_status -> int = "caml_curl_multi_socket_action"
 
-  let action_timeout mt = ignore (socket_action mt None EV_AUTO)
+  let action_timeout' mt = socket_action mt None EV_AUTO
+  let action_timeout mt = ignore (action_timeout' mt)
   let action mt fd status = socket_action mt (Some fd) status
 
   external timeout : mt -> int = "caml_curl_multi_timeout"

--- a/curl.mli
+++ b/curl.mli
@@ -1280,9 +1280,19 @@ module Multi : sig
   val action_all : mt -> int
 
   (** inform libcurl that timeout occured
+      @return the number of handles still active
       @raise Error on errors
   *)
-  val action_timeout : mt -> unit
+  val action_timeout' : mt -> int
+
+  (** inform libcurl that timeout occured
+      @deprecated since 0.10.1.
+      This function may finish {!type:Curl.t} handles.
+      Therefore it should return the possibly changed number of still active
+      handles. Use {!val:action_timeout'} instead.
+      @raise Error on errors
+  *)
+  val action_timeout : mt -> unit [@@ocaml.deprecated "Use action_timeout' instead"]
 
   (** [action mt fd status] informs libcurl about event on the specified socket.
       [status] specifies socket status. Perform pending data transfers.


### PR DESCRIPTION
On timeout easy handles may finish (with curlCode 28 Timeout). Therefore return the number of remaining handles from `Multi.action_timeout`.
This breaks compilation when warning # 10 is configured as fatal. It might be desirable to trigger this warning.